### PR TITLE
Add DimensionConnector to CalcMember

### DIFF
--- a/org.eclipse.daanse.rolap.mapping.api/src/main/java/org/eclipse/daanse/rolap/mapping/api/model/AggregationTableMapping.java
+++ b/org.eclipse.daanse.rolap.mapping.api/src/main/java/org/eclipse/daanse/rolap/mapping/api/model/AggregationTableMapping.java
@@ -30,4 +30,6 @@ public interface AggregationTableMapping {
 
     boolean isIgnorecase();
 
+    String getId();
+
 }

--- a/org.eclipse.daanse.rolap.mapping.api/src/main/java/org/eclipse/daanse/rolap/mapping/api/model/CalculatedMemberMapping.java
+++ b/org.eclipse.daanse.rolap.mapping.api/src/main/java/org/eclipse/daanse/rolap/mapping/api/model/CalculatedMemberMapping.java
@@ -28,6 +28,8 @@ public interface CalculatedMemberMapping extends AbstractElementMapping {
 
     HierarchyMapping getHierarchy();
 
+    DimensionConnectorMapping getDimensionConector();
+
     String getParent();
 
 }

--- a/org.eclipse.daanse.rolap.mapping.emf/src/main/resources/model/org.eclipse.daanse.rolap.mapping.ecore
+++ b/org.eclipse.daanse.rolap.mapping.emf/src/main/resources/model/org.eclipse.daanse.rolap.mapping.ecore
@@ -168,6 +168,8 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="overrideDimensionName"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="level" eType="#//Level"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
+        iD="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="TimeDimension" eSuperTypes="#//Dimension #//ITimeDimension"/>
   <eClassifiers xsi:type="ecore:EClass" name="StandardDimension" eSuperTypes="#//Dimension #//IStandardDimension"/>
@@ -242,6 +244,7 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="parent" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="visible" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="hierarchy" eType="#//Hierarchy"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="dimensionConector" eType="#//DimensionConnector"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="CalculatedMemberProperty" eSuperTypes="#//AbstractElement #//ICalculatedMemberProperty">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="expression" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String"/>
@@ -435,6 +438,8 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="aggregationMeasureFactCounts"
         upperBound="-1" eType="#//AggregationMeasureFactCount" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="ignorecase" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
+        iD="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="AggregationName" eSuperTypes="#//AggregationTable #//IAggregationName">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="approxRowCount" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String"/>

--- a/org.eclipse.daanse.rolap.mapping.emf/src/main/resources/model/org.eclipse.daanse.rolap.mapping.genmodel
+++ b/org.eclipse.daanse.rolap.mapping.emf/src/main/resources/model/org.eclipse.daanse.rolap.mapping.genmodel
@@ -134,6 +134,7 @@
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//DimensionConnector/dimension"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//DimensionConnector/overrideDimensionName"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//DimensionConnector/level"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//DimensionConnector/id"/>
     </genClasses>
     <genClasses ecoreClass="org.eclipse.daanse.rolap.mapping.ecore#//TimeDimension"/>
     <genClasses ecoreClass="org.eclipse.daanse.rolap.mapping.ecore#//StandardDimension"/>
@@ -193,6 +194,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//CalculatedMember/parent"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//CalculatedMember/visible"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//CalculatedMember/hierarchy"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//CalculatedMember/dimensionConector"/>
     </genClasses>
     <genClasses ecoreClass="org.eclipse.daanse.rolap.mapping.ecore#//CalculatedMemberProperty">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//CalculatedMemberProperty/expression"/>
@@ -345,6 +347,7 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//AggregationTable/aggregationLevels"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//AggregationTable/aggregationMeasureFactCounts"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//AggregationTable/ignorecase"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//AggregationTable/id"/>
     </genClasses>
     <genClasses ecoreClass="org.eclipse.daanse.rolap.mapping.ecore#//AggregationName">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//AggregationName/approxRowCount"/>


### PR DESCRIPTION
in cases where we have the same hierarchy in multiple Dimensions that are connected via DimensionConnector to a Cube this helps to find out which hierarchy in which Dimension we want.