### PR TITLE
use PROTOTYPE scope and explicit set service

### DIFF
--- a/instance/complex/foodmart/src/main/java/org/eclipse/daanse/rolap/mapping/example/complex/foodmart/ExampleSupplier.java
+++ b/instance/complex/foodmart/src/main/java/org/eclipse/daanse/rolap/mapping/example/complex/foodmart/ExampleSupplier.java
@@ -55,9 +55,10 @@ import org.eclipse.daanse.rolap.mapping.pojo.TableQueryMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.TimeDimensionMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.VirtualCubeMappingImpl;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
 
 @MappingInstance(kind = Kind.COMPLEX, source = Source.POJO, number = "3")
-@Component
+@Component(service =  RolapContextMappingSupplier.class, scope = ServiceScope.PROTOTYPE)
 public class ExampleSupplier implements RolapContextMappingSupplier {
 
     private static final String MEMBER_ORDINAL = "MEMBER_ORDINAL";

--- a/instance/complex/steelwheels/src/main/java/org/eclipse/daanse/rolap/mapping/example/complex/steelwheels/ExampleSupplier.java
+++ b/instance/complex/steelwheels/src/main/java/org/eclipse/daanse/rolap/mapping/example/complex/steelwheels/ExampleSupplier.java
@@ -19,45 +19,24 @@ import org.eclipse.daanse.rolap.mapping.api.model.RolapContextMapping;
 import org.eclipse.daanse.rolap.mapping.instance.api.Kind;
 import org.eclipse.daanse.rolap.mapping.instance.api.MappingInstance;
 import org.eclipse.daanse.rolap.mapping.instance.api.Source;
-import org.eclipse.daanse.rolap.mapping.pojo.AccessCubeGrantMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.AccessHierarchyGrantMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.AccessMemberGrantMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.AccessRoleMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.AccessSchemaGrantMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.AggregationColumnNameMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.AggregationExcludeMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.AggregationForeignKeyMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.AggregationLevelMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.AggregationMeasureMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.AggregationNameMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.AnnotationMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.CalculatedMemberMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.CalculatedMemberPropertyMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.CatalogMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.DimensionConnectorMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.DocumentationMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.HierarchyMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.JoinQueryMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.JoinedQueryElementMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.LevelMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.MeasureGroupMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.MeasureMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.MemberPropertyMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.NamedSetMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.ParentChildLinkMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.PhysicalCubeMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.RolapContextMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.SQLExpressionMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.SQLMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.SchemaMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.StandardDimensionMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.TableQueryMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.TimeDimensionMappingImpl;
-import org.eclipse.daanse.rolap.mapping.pojo.VirtualCubeMappingImpl;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
 
 @MappingInstance(kind = Kind.COMPLEX, source = Source.POJO, number = "4")
-@Component
+@Component(service =  RolapContextMappingSupplier.class, scope = ServiceScope.PROTOTYPE)
 public class ExampleSupplier implements RolapContextMappingSupplier {
 
     private static final String STATUS = "STATUS";

--- a/instance/tutorial/basic.cube.minimal/src/main/java/org/eclipse/daanse/rolap/mapping/example/tutorial/basic/cube/minimal/ExampleSupplier.java
+++ b/instance/tutorial/basic.cube.minimal/src/main/java/org/eclipse/daanse/rolap/mapping/example/tutorial/basic/cube/minimal/ExampleSupplier.java
@@ -28,9 +28,10 @@ import org.eclipse.daanse.rolap.mapping.pojo.RolapContextMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.SchemaMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.TableQueryMappingImpl;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
 
 @MappingInstance(kind = Kind.TUTORIAL, source = Source.POJO, number = "2")
-@Component
+@Component(service =  RolapContextMappingSupplier.class, scope = ServiceScope.PROTOTYPE)
 public class ExampleSupplier implements RolapContextMappingSupplier {
 
     private final static String name = "Minimal Physical Cube";

--- a/instance/tutorial/basic.structure.plain/src/main/java/org/eclipse/daanse/rolap/mapping/instance/tutorial/basic/structure/plain/ExampleSupplier.java
+++ b/instance/tutorial/basic.structure.plain/src/main/java/org/eclipse/daanse/rolap/mapping/instance/tutorial/basic/structure/plain/ExampleSupplier.java
@@ -24,9 +24,10 @@ import org.eclipse.daanse.rolap.mapping.pojo.DocumentationMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.RolapContextMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.SchemaMappingImpl;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
 
 @MappingInstance(kind = Kind.TUTORIAL, source = Source.POJO, number = "1")
-@Component
+@Component(service =  RolapContextMappingSupplier.class, scope = ServiceScope.PROTOTYPE)
 public class ExampleSupplier implements RolapContextMappingSupplier {
 
     private final static String name = "Structure of a Mapping";

--- a/mondrian.jaxb/src/test/java/org/eclipse/daanse/rolap/mapping/mondrian/model/MinimumSchemaTest.java
+++ b/mondrian.jaxb/src/test/java/org/eclipse/daanse/rolap/mapping/mondrian/model/MinimumSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
PROTOTYPE because a change in a object in one supplier does not harm others e.g. in paralel tests. Objects are not immutable