### PR TITLE
rm deprecated Name of the dimension that this member belongs to.

### DIFF
--- a/api/src/main/java/org/eclipse/daanse/rolap/mapping/api/model/CalculatedMemberMapping.java
+++ b/api/src/main/java/org/eclipse/daanse/rolap/mapping/api/model/CalculatedMemberMapping.java
@@ -28,8 +28,6 @@ public interface CalculatedMemberMapping extends AbstractElementMapping {
 
     HierarchyMapping getHierarchy();
 
-    DimensionConnectorMapping getDimensionConector();
-
     String getParent();
 
     boolean isVisible();

--- a/api/src/main/java/org/eclipse/daanse/rolap/mapping/api/model/DimensionConnectorMapping.java
+++ b/api/src/main/java/org/eclipse/daanse/rolap/mapping/api/model/DimensionConnectorMapping.java
@@ -26,4 +26,6 @@ public interface DimensionConnectorMapping {
 
     String getOverrideDimensionName();
 
+    PhysicalCubeMapping getPhysicalCube();
+
 }

--- a/emf/src/main/resources/model/org.eclipse.daanse.rolap.mapping.ecore
+++ b/emf/src/main/resources/model/org.eclipse.daanse.rolap.mapping.ecore
@@ -234,7 +234,6 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="parent" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="visible" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="hierarchy" eType="#//Hierarchy"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="dimensionConector" eType="#//DimensionConnector"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="CalculatedMemberProperty" eSuperTypes="#//AbstractElement #//ICalculatedMemberProperty">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="expression" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String"/>

--- a/emf/src/main/resources/model/org.eclipse.daanse.rolap.mapping.ecore
+++ b/emf/src/main/resources/model/org.eclipse.daanse.rolap.mapping.ecore
@@ -71,8 +71,6 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="defaultAccessRole" eType="#//AccessRole"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Cube" abstract="true" eSuperTypes="#//AbstractElement #//ICube">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="dimensionConnectors" upperBound="-1"
-        eType="#//DimensionConnector" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="calculatedMembers" upperBound="-1"
         eType="#//CalculatedMember" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="namedSets" upperBound="-1"
@@ -86,6 +84,8 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="defaultMeasure" eType="#//Measure"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="PhysicalCube" eSuperTypes="#//Cube #//IPhysicalCube">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="dimensionConnectors" upperBound="-1"
+        eType="#//DimensionConnector" containment="true" eOpposite="#//DimensionConnector/physicalCube"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="query" lowerBound="1" eType="#//Query"
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="writebackTable" eType="#//WritebackTable"
@@ -95,6 +95,8 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="cache" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="VirtualCube" eSuperTypes="#//Cube #//IVirtualCube">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="dimensionConnectors" upperBound="-1"
+        eType="#//DimensionConnector"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="cubeUsages" lowerBound="1"
         upperBound="-1" eType="#//CubeConnector" containment="true"/>
   </eClassifiers>
@@ -160,6 +162,8 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="level" eType="#//Level"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
         iD="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="physicalCube" lowerBound="1"
+        eType="#//PhysicalCube" eOpposite="#//PhysicalCube/dimensionConnectors"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="TimeDimension" eSuperTypes="#//Dimension #//ITimeDimension"/>
   <eClassifiers xsi:type="ecore:EClass" name="StandardDimension" eSuperTypes="#//Dimension #//IStandardDimension"/>

--- a/emf/src/main/resources/model/org.eclipse.daanse.rolap.mapping.genmodel
+++ b/emf/src/main/resources/model/org.eclipse.daanse.rolap.mapping.genmodel
@@ -58,7 +58,6 @@
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//Schema/defaultAccessRole"/>
     </genClasses>
     <genClasses image="false" ecoreClass="org.eclipse.daanse.rolap.mapping.ecore#//Cube">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//Cube/dimensionConnectors"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//Cube/calculatedMembers"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//Cube/namedSets"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//Cube/kpis"/>
@@ -68,12 +67,14 @@
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//Cube/defaultMeasure"/>
     </genClasses>
     <genClasses ecoreClass="org.eclipse.daanse.rolap.mapping.ecore#//PhysicalCube">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//PhysicalCube/dimensionConnectors"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//PhysicalCube/query"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//PhysicalCube/writebackTable"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//PhysicalCube/action"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//PhysicalCube/cache"/>
     </genClasses>
     <genClasses ecoreClass="org.eclipse.daanse.rolap.mapping.ecore#//VirtualCube">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//VirtualCube/dimensionConnectors"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//VirtualCube/cubeUsages"/>
     </genClasses>
     <genClasses ecoreClass="org.eclipse.daanse.rolap.mapping.ecore#//CubeConnector">
@@ -128,6 +129,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//DimensionConnector/overrideDimensionName"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//DimensionConnector/level"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//DimensionConnector/id"/>
+      <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//DimensionConnector/physicalCube"/>
     </genClasses>
     <genClasses ecoreClass="org.eclipse.daanse.rolap.mapping.ecore#//TimeDimension"/>
     <genClasses ecoreClass="org.eclipse.daanse.rolap.mapping.ecore#//StandardDimension"/>
@@ -187,7 +189,6 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//CalculatedMember/parent"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//CalculatedMember/visible"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//CalculatedMember/hierarchy"/>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rolap.mapping.ecore#//CalculatedMember/dimensionConector"/>
     </genClasses>
     <genClasses ecoreClass="org.eclipse.daanse.rolap.mapping.ecore#//CalculatedMemberProperty">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rolap.mapping.ecore#//CalculatedMemberProperty/expression"/>

--- a/modifier/src/main/java/org/eclipse/daanse/rolap/mapping/modifier/AbstractMappingModifier.java
+++ b/modifier/src/main/java/org/eclipse/daanse/rolap/mapping/modifier/AbstractMappingModifier.java
@@ -2620,12 +2620,11 @@ public abstract class AbstractMappingModifier implements CatalogMappingSupplier 
             String displayFolder = calculatedMemberDisplayFolder(calculatedMember);
             String formatString = calculatedMemberFormatString(calculatedMember);
             HierarchyMapping hierarchy = calculatedMemberHierarchy(calculatedMember);
-            DimensionConnectorMapping dimensionConector = calculatedMemberDimensionConector(calculatedMember);
             String parent = calculatedMemberParent(calculatedMember);
             boolean visible = calculatedMemberVisible(calculatedMember);
 
             return createCalculatedMember(annotations, id, description, name, documentation, calculatedMemberProperties,
-                cellFormatter, formula, displayFolder, formatString, hierarchy, dimensionConector, parent, visible);
+                cellFormatter, formula, displayFolder, formatString, hierarchy,  parent, visible);
         }
         return null;
     }
@@ -2635,7 +2634,7 @@ public abstract class AbstractMappingModifier implements CatalogMappingSupplier 
         String id, String description, String name, DocumentationMapping documentation,
         List<? extends CalculatedMemberPropertyMapping> calculatedMemberProperties,
         CellFormatterMapping cellFormatter, String formula, String displayFolder, String formatString,
-        HierarchyMapping hierarchy, DimensionConnectorMapping dimensionConector, String parent, boolean visible
+        HierarchyMapping hierarchy, String parent, boolean visible
     );
 
     protected boolean calculatedMemberVisible(CalculatedMemberMapping calculatedMember) {
@@ -2644,10 +2643,6 @@ public abstract class AbstractMappingModifier implements CatalogMappingSupplier 
 
     protected String calculatedMemberParent(CalculatedMemberMapping calculatedMember) {
         return calculatedMember.getParent();
-    }
-
-    protected DimensionConnectorMapping calculatedMemberDimensionConector(CalculatedMemberMapping calculatedMember) {
-        return dimensionConnector(calculatedMember.getDimensionConector());
     }
 
     protected HierarchyMapping calculatedMemberHierarchy(CalculatedMemberMapping calculatedMember) {

--- a/modifier/src/main/java/org/eclipse/daanse/rolap/mapping/modifier/PojoMappingModifier.java
+++ b/modifier/src/main/java/org/eclipse/daanse/rolap/mapping/modifier/PojoMappingModifier.java
@@ -772,7 +772,7 @@ public class PojoMappingModifier extends AbstractMappingModifier {
         String description, String name, DocumentationMapping documentation,
         List<? extends CalculatedMemberPropertyMapping> calculatedMemberProperties,
         CellFormatterMapping cellFormatter, String formula, String displayFolder, String formatString,
-        HierarchyMapping hierarchy, DimensionConnectorMapping dimensionConector, String parent, boolean visible
+        HierarchyMapping hierarchy, String parent, boolean visible
     ) {
         return CalculatedMemberMappingImpl.builder()
             .withAnnotations((List<AnnotationMappingImpl>) annotations)
@@ -786,7 +786,6 @@ public class PojoMappingModifier extends AbstractMappingModifier {
             .withDisplayFolder(displayFolder)
             .withFormatString(formatString)
             .withHierarchy((HierarchyMappingImpl) hierarchy)
-            .withDimensionConector((DimensionConnectorMappingImpl) dimensionConector)
             .withParent(parent)
             .withVisible(visible)
             .build();

--- a/pojo/src/main/java/org/eclipse/daanse/rolap/mapping/pojo/CalculatedMemberMappingImpl.java
+++ b/pojo/src/main/java/org/eclipse/daanse/rolap/mapping/pojo/CalculatedMemberMappingImpl.java
@@ -44,7 +44,6 @@ public class CalculatedMemberMappingImpl extends AbstractElementMappingImpl impl
         this.displayFolder = builder.displayFolder;
         this.formatString = builder.formatString;
         this.hierarchy = builder.hierarchy;
-        this.dimensionConector = builder.dimensionConector;
         this.parent = builder.parent;
         this.setVisible(builder.visible);
         super.setAnnotations(builder.annotations);
@@ -137,7 +136,6 @@ public class CalculatedMemberMappingImpl extends AbstractElementMappingImpl impl
         private String displayFolder;
         private String formatString;
         private HierarchyMappingImpl hierarchy;
-        private DimensionConnectorMappingImpl dimensionConector;
         private String parent;
         private boolean visible;
         private List<AnnotationMappingImpl> annotations = new ArrayList<>();
@@ -177,11 +175,6 @@ public class CalculatedMemberMappingImpl extends AbstractElementMappingImpl impl
 
         public Builder withHierarchy(HierarchyMappingImpl hierarchy) {
             this.hierarchy = hierarchy;
-            return this;
-        }
-
-        public Builder withDimensionConector(DimensionConnectorMappingImpl dimensionConector) {
-            this.dimensionConector = dimensionConector;
             return this;
         }
 

--- a/pojo/src/main/java/org/eclipse/daanse/rolap/mapping/pojo/DimensionConnectorMappingImpl.java
+++ b/pojo/src/main/java/org/eclipse/daanse/rolap/mapping/pojo/DimensionConnectorMappingImpl.java
@@ -28,6 +28,8 @@ public class DimensionConnectorMappingImpl implements DimensionConnectorMapping 
 
     private String overrideDimensionName;
 
+    private PhysicalCubeMappingImpl physicalCube;
+
     private DimensionConnectorMappingImpl(Builder builder) {
         this.foreignKey = builder.foreignKey;
         this.level = builder.level;
@@ -35,7 +37,8 @@ public class DimensionConnectorMappingImpl implements DimensionConnectorMapping 
         this.visible = builder.visible;
         this.dimension = builder.dimension;
         this.overrideDimensionName = builder.overrideDimensionName;
-    }
+        this.physicalCube = builder.physicalCube;
+}
 
     public String getForeignKey() {
         return foreignKey;
@@ -89,6 +92,14 @@ public class DimensionConnectorMappingImpl implements DimensionConnectorMapping 
         return new Builder();
     }
 
+    public PhysicalCubeMappingImpl getPhysicalCube() {
+        return physicalCube;
+    }
+
+    public void setPhysicalCube(PhysicalCubeMappingImpl physicalCube) {
+        this.physicalCube = physicalCube;
+    }
+
     public static final class Builder {
         private String foreignKey;
         private LevelMappingImpl level;
@@ -96,6 +107,7 @@ public class DimensionConnectorMappingImpl implements DimensionConnectorMapping 
         private boolean visible;
         private DimensionMappingImpl dimension;
         private String overrideDimensionName;
+        private PhysicalCubeMappingImpl physicalCube;
 
         private Builder() {
         }
@@ -127,6 +139,11 @@ public class DimensionConnectorMappingImpl implements DimensionConnectorMapping 
 
         public Builder withOverrideDimensionName(String overrideDimensionName) {
             this.overrideDimensionName = overrideDimensionName;
+            return this;
+        }
+
+        public Builder withPhysicalCube(PhysicalCubeMappingImpl physicalCube) {
+            this.physicalCube = physicalCube;
             return this;
         }
 


### PR DESCRIPTION
Deprecated: use {@code hierarchy} attribute instead.