### PR TITLE
minor enhancements on tutorial serialisation

### DIFF
--- a/instance/emf/serializer/src/test/java/org/eclipse/daanse/rolap/mapping/instance/emf/serializer/ResourceSetWriteReadTest.java
+++ b/instance/emf/serializer/src/test/java/org/eclipse/daanse/rolap/mapping/instance/emf/serializer/ResourceSetWriteReadTest.java
@@ -338,7 +338,8 @@ A recommended reading order is provided below to help you build your understandi
         sbReadme.append("\n");
         sbReadme.append("```");
         sbReadme.append("\n");
-        sbReadme.append("[Mapping file](./"+name+"/mapping/catalog.xmi)");
+        sbReadme.append("<a href=\"./"+name+"/mapping/catalog.xmi\" download>Download Mapping File</a>");
+
         sbReadme.append("\n");
 
         sbReadme.append("\n");


### PR DESCRIPTION
- Replaced markdown link with an HTML download link
- Added `download` attribute for direct file download
- Improved usability for accessing the mapping file
- Ensured compatibility with existing README structure
