### PR TITLE
- Adjusted class and enum links in `package.peb` to use `.md` files

### DIFF
--- a/emf/src/test/resources/templates/package.peb
+++ b/emf/src/test/resources/templates/package.peb
@@ -19,7 +19,7 @@ A full overview of the package is given in the following diagram. It shows all c
 {% for cls in package.eClassifiers%}
 {% if isEClass(cls) %}
 {% if not isEClassInterface(cls) %}
-- [Class {{ cls.name }}](#class-{{ cls.name | lower }})
+- [Class {{ cls.name }}](./class-{{ cls.name }}.md)
 {% endif %}
 {% endif %}
 {% endfor %}
@@ -27,7 +27,7 @@ A full overview of the package is given in the following diagram. It shows all c
 
 {% for en in package.eClassifiers %}
 {% if isEEnum(en) %}
-- [Enum {{ en.name }}](#enum-{{ en.name | lower }})
+- [Enum {{ en.name }}](./enum-{{ en.name }}.md)
 {% endif %}
 {% endfor %}
 

--- a/instance/emf/serializer/src/test/java/org/eclipse/daanse/rolap/mapping/instance/emf/serializer/ResourceSetWriteReadTest.java
+++ b/instance/emf/serializer/src/test/java/org/eclipse/daanse/rolap/mapping/instance/emf/serializer/ResourceSetWriteReadTest.java
@@ -291,7 +291,7 @@ public class ResourceSetWriteReadTest {
                 r.save(baosDummy, null);
 
                 String cleaned = baosDummy.toString();
-                // .replace("file:" + fileCatalog.toAbsolutePath().toString(), "");
+                cleaned=cleaned.replace("catalog.xmi#", "");
 
                 cleaned = cleaned.substring(cleaned.indexOf("\n") + 1);
                 cleaned = cleaned.replace("xmlns:roma=\"https://www.daanse.org/spec/org.eclipse.daanse.rolap.mapping\"",


### PR DESCRIPTION
- Replaced outdated anchor-based links with file-based links
- Updated `ResourceSetWriteReadTest` to clean up `catalog.xmi#` references
- Removed commented-out code in `ResourceSetWriteReadTest`
- Improved readability of cleaned string processing logic
