### PR TITLE
refactor(instance): build indexes through the cwm helper, not by hand

### DIFF
--- a/instance/emf/complex/accounting/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/accounting/CatalogSupplier.java
+++ b/instance/emf/complex/accounting/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/accounting/CatalogSupplier.java
@@ -17,7 +17,7 @@ import java.util.List;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 
 import org.eclipse.daanse.rolap.mapping.instance.api.CatalogRef;
 import org.eclipse.daanse.rolap.mapping.instance.api.DocSection;
@@ -572,13 +572,13 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         databaseSchema = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE
                 .createSchema();
 
-        Column bookingIdColumn = createColumn("BOOKING_ID", SqlSimpleTypes.Sql99.integerType());
-        Column bookingYearKeyColumn = createColumn("YEAR_KEY", SqlSimpleTypes.Sql99.integerType());
-        Column bookingAccountKeyColumn = createColumn("ACCOUNT_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column bookingOrgUnitKeyColumn = createColumn("ORG_UNIT_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column bookingAmountIstColumn = createColumn("AMOUNT_IST", SqlSimpleTypes.Sql99.integerType());
-        Column bookingAmountPlanColumn = createColumn("AMOUNT_PLAN", SqlSimpleTypes.Sql99.integerType());
-        Column bookingCommentColumn = createColumn("COMMENT", SqlSimpleTypes.Sql99.varcharType());
+        Column bookingIdColumn = createColumn("BOOKING_ID", SQLSimpleTypes.Sql99.integerType());
+        Column bookingYearKeyColumn = createColumn("YEAR_KEY", SQLSimpleTypes.Sql99.integerType());
+        Column bookingAccountKeyColumn = createColumn("ACCOUNT_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column bookingOrgUnitKeyColumn = createColumn("ORG_UNIT_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column bookingAmountIstColumn = createColumn("AMOUNT_IST", SQLSimpleTypes.Sql99.integerType());
+        Column bookingAmountPlanColumn = createColumn("AMOUNT_PLAN", SQLSimpleTypes.Sql99.integerType());
+        Column bookingCommentColumn = createColumn("COMMENT", SQLSimpleTypes.Sql99.varcharType());
 
         Table bookingTable = createTable(TABLE_BOOKING,
                 List.of(bookingIdColumn, bookingYearKeyColumn, bookingAccountKeyColumn,
@@ -586,13 +586,13 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
                         bookingAmountPlanColumn, bookingCommentColumn));
         databaseSchema.getOwnedElement().add(bookingTable);
 
-        Column wbIdColumn = createColumn("ID", SqlSimpleTypes.Sql99.varcharType());
-        Column wbUserColumn = createColumn("USER", SqlSimpleTypes.Sql99.varcharType());
-        Column wbYearKeyColumn = createColumn("YEAR_KEY", SqlSimpleTypes.Sql99.integerType());
-        Column wbAccountKeyColumn = createColumn("ACCOUNT_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column wbOrgUnitKeyColumn = createColumn("ORG_UNIT_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column wbAmountPlanColumn = createColumn("AMOUNT_PLAN", SqlSimpleTypes.Sql99.integerType());
-        Column wbCommentColumn = createColumn("COMMENT", SqlSimpleTypes.Sql99.varcharType());
+        Column wbIdColumn = createColumn("ID", SQLSimpleTypes.Sql99.varcharType());
+        Column wbUserColumn = createColumn("USER", SQLSimpleTypes.Sql99.varcharType());
+        Column wbYearKeyColumn = createColumn("YEAR_KEY", SQLSimpleTypes.Sql99.integerType());
+        Column wbAccountKeyColumn = createColumn("ACCOUNT_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column wbOrgUnitKeyColumn = createColumn("ORG_UNIT_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column wbAmountPlanColumn = createColumn("AMOUNT_PLAN", SQLSimpleTypes.Sql99.integerType());
+        Column wbCommentColumn = createColumn("COMMENT", SQLSimpleTypes.Sql99.varcharType());
 
         writebackPhysicalTable = createTable(TABLE_BOOKINGWB,
                 List.of(wbIdColumn, wbUserColumn, wbYearKeyColumn, wbAccountKeyColumn,
@@ -603,12 +603,12 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         // denormalised table (same shape as ORGUNIT). L1 is the top
         // category (EXPENSES / REVENUE), L2 the account group
         // (PERSONNEL / RENT / ...) and L3 the leaf ledger account.
-        Column accountL1KeyColumn = createColumn("L1_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column accountL1NameColumn = createColumn("L1_NAME", SqlSimpleTypes.Sql99.varcharType());
-        Column accountL2KeyColumn = createColumn("L2_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column accountL2NameColumn = createColumn("L2_NAME", SqlSimpleTypes.Sql99.varcharType());
-        Column accountL3KeyColumn = createColumn("L3_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column accountL3NameColumn = createColumn("L3_NAME", SqlSimpleTypes.Sql99.varcharType());
+        Column accountL1KeyColumn = createColumn("L1_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column accountL1NameColumn = createColumn("L1_NAME", SQLSimpleTypes.Sql99.varcharType());
+        Column accountL2KeyColumn = createColumn("L2_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column accountL2NameColumn = createColumn("L2_NAME", SQLSimpleTypes.Sql99.varcharType());
+        Column accountL3KeyColumn = createColumn("L3_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column accountL3NameColumn = createColumn("L3_NAME", SQLSimpleTypes.Sql99.varcharType());
 
         Table accountTable = createTable(TABLE_ACCOUNT,
                 List.of(accountL1KeyColumn, accountL1NameColumn,
@@ -616,18 +616,18 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
                         accountL3KeyColumn, accountL3NameColumn));
         databaseSchema.getOwnedElement().add(accountTable);
 
-        Column yearKeyColumn = createColumn("YEAR_KEY", SqlSimpleTypes.Sql99.integerType());
-        Column yearNameColumn = createColumn("YEAR_NAME", SqlSimpleTypes.Sql99.varcharType());
+        Column yearKeyColumn = createColumn("YEAR_KEY", SQLSimpleTypes.Sql99.integerType());
+        Column yearNameColumn = createColumn("YEAR_NAME", SQLSimpleTypes.Sql99.varcharType());
 
         Table yearTable = createTable(TABLE_YEAR, List.of(yearKeyColumn, yearNameColumn));
         databaseSchema.getOwnedElement().add(yearTable);
 
-        Column ouL1KeyColumn = createColumn("L1_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column ouL1NameColumn = createColumn("L1_NAME", SqlSimpleTypes.Sql99.varcharType());
-        Column ouL2KeyColumn = createColumn("L2_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column ouL2NameColumn = createColumn("L2_NAME", SqlSimpleTypes.Sql99.varcharType());
-        Column ouL3KeyColumn = createColumn("L3_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column ouL3NameColumn = createColumn("L3_NAME", SqlSimpleTypes.Sql99.varcharType());
+        Column ouL1KeyColumn = createColumn("L1_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column ouL1NameColumn = createColumn("L1_NAME", SQLSimpleTypes.Sql99.varcharType());
+        Column ouL2KeyColumn = createColumn("L2_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column ouL2NameColumn = createColumn("L2_NAME", SQLSimpleTypes.Sql99.varcharType());
+        Column ouL3KeyColumn = createColumn("L3_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column ouL3NameColumn = createColumn("L3_NAME", SQLSimpleTypes.Sql99.varcharType());
 
         Table orgUnitTable = createTable(TABLE_ORGUNIT,
                 List.of(ouL1KeyColumn, ouL1NameColumn, ouL2KeyColumn, ouL2NameColumn, ouL3KeyColumn, ouL3NameColumn));

--- a/instance/emf/complex/accountingonecube/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/accountingonecube/CatalogSupplier.java
+++ b/instance/emf/complex/accountingonecube/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/accountingonecube/CatalogSupplier.java
@@ -17,7 +17,7 @@ import java.util.List;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 
 import org.eclipse.daanse.rolap.mapping.instance.api.CatalogRef;
 import org.eclipse.daanse.rolap.mapping.instance.api.DocSection;
@@ -548,13 +548,13 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         databaseSchema = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE
                 .createSchema();
 
-        Column bookingIdColumn = createColumn("BOOKING_ID", SqlSimpleTypes.Sql99.integerType());
-        Column bookingYearKeyColumn = createColumn("YEAR_KEY", SqlSimpleTypes.Sql99.integerType());
-        Column bookingAccountKeyColumn = createColumn("ACCOUNT_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column bookingOrgUnitKeyColumn = createColumn("ORG_UNIT_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column bookingAmountIstColumn = createColumn("AMOUNT_IST", SqlSimpleTypes.Sql99.integerType());
-        Column bookingAmountPlanColumn = createColumn("AMOUNT_PLAN", SqlSimpleTypes.Sql99.integerType());
-        Column bookingCommentColumn = createColumn("COMMENT", SqlSimpleTypes.Sql99.varcharType());
+        Column bookingIdColumn = createColumn("BOOKING_ID", SQLSimpleTypes.Sql99.integerType());
+        Column bookingYearKeyColumn = createColumn("YEAR_KEY", SQLSimpleTypes.Sql99.integerType());
+        Column bookingAccountKeyColumn = createColumn("ACCOUNT_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column bookingOrgUnitKeyColumn = createColumn("ORG_UNIT_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column bookingAmountIstColumn = createColumn("AMOUNT_IST", SQLSimpleTypes.Sql99.integerType());
+        Column bookingAmountPlanColumn = createColumn("AMOUNT_PLAN", SQLSimpleTypes.Sql99.integerType());
+        Column bookingCommentColumn = createColumn("COMMENT", SQLSimpleTypes.Sql99.varcharType());
 
         Table bookingTable = createTable(TABLE_BOOKING,
                 List.of(bookingIdColumn, bookingYearKeyColumn, bookingAccountKeyColumn,
@@ -562,15 +562,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
                         bookingAmountPlanColumn, bookingCommentColumn));
         databaseSchema.getOwnedElement().add(bookingTable);
 
-        Column wbIdColumn = createColumn("ID", SqlSimpleTypes.Sql99.varcharType());
-        Column wbUserColumn = createColumn("USER", SqlSimpleTypes.Sql99.varcharType());
-        Column wbYearKeyColumn = createColumn("YEAR_KEY", SqlSimpleTypes.Sql99.integerType());
-        Column wbAccountKeyColumn = createColumn("ACCOUNT_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column wbOrgUnitKeyColumn = createColumn("ORG_UNIT_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column wbBookingAmountIstColumn = createColumn("AMOUNT_IST", SqlSimpleTypes.Sql99.integerType());
-        Column wbAmountIstColumn = createColumn("AMOUNT_IST", SqlSimpleTypes.Sql99.integerType());
-        Column wbAmountPlanColumn = createColumn("AMOUNT_PLAN", SqlSimpleTypes.Sql99.integerType());
-        Column wbCommentColumn = createColumn("COMMENT", SqlSimpleTypes.Sql99.varcharType());
+        Column wbIdColumn = createColumn("ID", SQLSimpleTypes.Sql99.varcharType());
+        Column wbUserColumn = createColumn("USER", SQLSimpleTypes.Sql99.varcharType());
+        Column wbYearKeyColumn = createColumn("YEAR_KEY", SQLSimpleTypes.Sql99.integerType());
+        Column wbAccountKeyColumn = createColumn("ACCOUNT_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column wbOrgUnitKeyColumn = createColumn("ORG_UNIT_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column wbBookingAmountIstColumn = createColumn("AMOUNT_IST", SQLSimpleTypes.Sql99.integerType());
+        Column wbAmountIstColumn = createColumn("AMOUNT_IST", SQLSimpleTypes.Sql99.integerType());
+        Column wbAmountPlanColumn = createColumn("AMOUNT_PLAN", SQLSimpleTypes.Sql99.integerType());
+        Column wbCommentColumn = createColumn("COMMENT", SQLSimpleTypes.Sql99.varcharType());
 
         writebackPhysicalTable = createTable(TABLE_BOOKINGWB,
                 List.of(wbIdColumn, wbUserColumn, wbYearKeyColumn, wbAccountKeyColumn,
@@ -581,12 +581,12 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         // denormalised table (same shape as ORGUNIT). L1 is the top
         // category (EXPENSES / REVENUE), L2 the account group
         // (PERSONNEL / RENT / ...) and L3 the leaf ledger account.
-        Column accountL1KeyColumn = createColumn("L1_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column accountL1NameColumn = createColumn("L1_NAME", SqlSimpleTypes.Sql99.varcharType());
-        Column accountL2KeyColumn = createColumn("L2_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column accountL2NameColumn = createColumn("L2_NAME", SqlSimpleTypes.Sql99.varcharType());
-        Column accountL3KeyColumn = createColumn("L3_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column accountL3NameColumn = createColumn("L3_NAME", SqlSimpleTypes.Sql99.varcharType());
+        Column accountL1KeyColumn = createColumn("L1_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column accountL1NameColumn = createColumn("L1_NAME", SQLSimpleTypes.Sql99.varcharType());
+        Column accountL2KeyColumn = createColumn("L2_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column accountL2NameColumn = createColumn("L2_NAME", SQLSimpleTypes.Sql99.varcharType());
+        Column accountL3KeyColumn = createColumn("L3_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column accountL3NameColumn = createColumn("L3_NAME", SQLSimpleTypes.Sql99.varcharType());
 
         Table accountTable = createTable(TABLE_ACCOUNT,
                 List.of(accountL1KeyColumn, accountL1NameColumn,
@@ -594,18 +594,18 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
                         accountL3KeyColumn, accountL3NameColumn));
         databaseSchema.getOwnedElement().add(accountTable);
 
-        Column yearKeyColumn = createColumn("YEAR_KEY", SqlSimpleTypes.Sql99.integerType());
-        Column yearNameColumn = createColumn("YEAR_NAME", SqlSimpleTypes.Sql99.varcharType());
+        Column yearKeyColumn = createColumn("YEAR_KEY", SQLSimpleTypes.Sql99.integerType());
+        Column yearNameColumn = createColumn("YEAR_NAME", SQLSimpleTypes.Sql99.varcharType());
 
         Table yearTable = createTable(TABLE_YEAR, List.of(yearKeyColumn, yearNameColumn));
         databaseSchema.getOwnedElement().add(yearTable);
 
-        Column ouL1KeyColumn = createColumn("L1_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column ouL1NameColumn = createColumn("L1_NAME", SqlSimpleTypes.Sql99.varcharType());
-        Column ouL2KeyColumn = createColumn("L2_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column ouL2NameColumn = createColumn("L2_NAME", SqlSimpleTypes.Sql99.varcharType());
-        Column ouL3KeyColumn = createColumn("L3_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column ouL3NameColumn = createColumn("L3_NAME", SqlSimpleTypes.Sql99.varcharType());
+        Column ouL1KeyColumn = createColumn("L1_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column ouL1NameColumn = createColumn("L1_NAME", SQLSimpleTypes.Sql99.varcharType());
+        Column ouL2KeyColumn = createColumn("L2_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column ouL2NameColumn = createColumn("L2_NAME", SQLSimpleTypes.Sql99.varcharType());
+        Column ouL3KeyColumn = createColumn("L3_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column ouL3NameColumn = createColumn("L3_NAME", SQLSimpleTypes.Sql99.varcharType());
 
         Table orgUnitTable = createTable(TABLE_ORGUNIT,
                 List.of(ouL1KeyColumn, ouL1NameColumn, ouL2KeyColumn, ouL2NameColumn, ouL3KeyColumn, ouL3NameColumn));

--- a/instance/emf/complex/csdl/bikeaccessories/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/csdl/bikeaccessories/CatalogSupplier.java
+++ b/instance/emf/complex/csdl/bikeaccessories/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/csdl/bikeaccessories/CatalogSupplier.java
@@ -48,7 +48,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.enumerations.NullableType;
 @MappingInstance(kind = Kind.COMPLEX, source = Source.EMF, number = "99.1.6", group = "Full Examples")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
@@ -491,706 +491,706 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
     static {
         COLUMN_ROW_NUMBER_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_FACT.setName("RowNumber");
-        COLUMN_ROW_NUMBER_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_KEY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_KEY_FACT.setName("ProductKey");
-        COLUMN_PRODUCT_KEY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_KEY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_ORDER_DATE_KEY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ORDER_DATE_KEY_FACT.setName("OrderDateKey");
-        COLUMN_ORDER_DATE_KEY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ORDER_DATE_KEY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DUE_DATE_KEY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DUE_DATE_KEY_FACT.setName("DueDateKey");
-        COLUMN_DUE_DATE_KEY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DUE_DATE_KEY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_SHIP_DATE_KEY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SHIP_DATE_KEY_FACT.setName("ShipDateKey");
-        COLUMN_SHIP_DATE_KEY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SHIP_DATE_KEY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMER_KEY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_KEY_FACT.setName("CustomerKey");
-        COLUMN_CUSTOMER_KEY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_KEY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PROMOTION_KEY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PROMOTION_KEY_FACT.setName("PromotionKey");
-        COLUMN_PROMOTION_KEY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PROMOTION_KEY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CURENCY_KEY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CURENCY_KEY_FACT.setName("CurrencyKey");
-        COLUMN_CURENCY_KEY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CURENCY_KEY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_SALES_TERITORY_KEY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_TERITORY_KEY_FACT.setName("SalesTerritoryKey");
-        COLUMN_SALES_TERITORY_KEY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SALES_TERITORY_KEY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_SALES_TERITORY_KEY_FACT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SALES_ORDER_NUMBER_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_ORDER_NUMBER_FACT.setName("SalesOrderNumber");
-        COLUMN_SALES_ORDER_NUMBER_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SALES_ORDER_NUMBER_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_SALES_ORDER_LINE_NUMBER_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_ORDER_LINE_NUMBER_FACT.setName("SalesOrderLineNumber");
-        COLUMN_SALES_ORDER_LINE_NUMBER_FACT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SALES_ORDER_LINE_NUMBER_FACT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_REVISION_NUMBER_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_REVISION_NUMBER_FACT.setName("RevisionNumber");
-        COLUMN_REVISION_NUMBER_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_REVISION_NUMBER_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_ORDER_QUANTITY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ORDER_QUANTITY_FACT.setName("OrderQuantity");
-        COLUMN_ORDER_QUANTITY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ORDER_QUANTITY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_UNIT_PRICE_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_PRICE_FACT.setName("UnitPrice");
-        COLUMN_UNIT_PRICE_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_UNIT_PRICE_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_EXTENDED_AMOUNT_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EXTENDED_AMOUNT_FACT.setName("ExtendedAmount");
-        COLUMN_EXTENDED_AMOUNT_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_EXTENDED_AMOUNT_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_UNIT_PRICE_DISCOUNT_PCT_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_PRICE_DISCOUNT_PCT_FACT.setName("UnitPriceDiscountPct");
-        COLUMN_UNIT_PRICE_DISCOUNT_PCT_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_UNIT_PRICE_DISCOUNT_PCT_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_DISCOUNT_AMOUNT_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DISCOUNT_AMOUNT_FACT.setName("DiscountAmount");
-        COLUMN_DISCOUNT_AMOUNT_FACT.setType(SqlSimpleTypes.Sql99.doublePrecisionType());
+        COLUMN_DISCOUNT_AMOUNT_FACT.setType(SQLSimpleTypes.Sql99.doublePrecisionType());
 
         COLUMN_PRODUCT_STANDART_COST_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_STANDART_COST_FACT.setName("ProductStandardCost");
-        COLUMN_PRODUCT_STANDART_COST_FACT.setType(SqlSimpleTypes.Sql99.doublePrecisionType());
+        COLUMN_PRODUCT_STANDART_COST_FACT.setType(SQLSimpleTypes.Sql99.doublePrecisionType());
 
         COLUMN_TOTAL_PRODUCT_COST_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TOTAL_PRODUCT_COST_FACT.setName("TotalProductCost");
-        COLUMN_TOTAL_PRODUCT_COST_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_TOTAL_PRODUCT_COST_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_SALES_AMOUNT_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_AMOUNT_FACT.setName("SalesAmount");
-        COLUMN_SALES_AMOUNT_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_SALES_AMOUNT_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_TAX_AMT_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TAX_AMT_FACT.setName("TaxAmt");
-        COLUMN_TAX_AMT_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_TAX_AMT_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_FREIGHT_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FREIGHT_FACT.setName("Freight");
-        COLUMN_FREIGHT_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_FREIGHT_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_CARRIER_TRACKING_NUMBER_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CARRIER_TRACKING_NUMBER_FACT.setName("CarrierTrackingNumber");
-        COLUMN_CARRIER_TRACKING_NUMBER_FACT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CARRIER_TRACKING_NUMBER_FACT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_CUSTOMER_PO_NUMBER_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_PO_NUMBER_FACT.setName("CustomerPONumber");
-        COLUMN_CUSTOMER_PO_NUMBER_FACT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CUSTOMER_PO_NUMBER_FACT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_EMPLOYEE_KEY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EMPLOYEE_KEY_FACT.setName("EmployeeKey");
-        COLUMN_EMPLOYEE_KEY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_EMPLOYEE_KEY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_BILLING_CUSTOMER_KEY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_BILLING_CUSTOMER_KEY_FACT.setName("BillingCustomerKey");
-        COLUMN_BILLING_CUSTOMER_KEY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_BILLING_CUSTOMER_KEY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_KEY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_KEY_FACT.setName("StoreKey");
-        COLUMN_STORE_KEY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_KEY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_TOTAL_SALES_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TOTAL_SALES_FACT.setName("TotalSales");
-        COLUMN_TOTAL_SALES_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TOTAL_SALES_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_ROW_NUMBER_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_CUSTOMER.setName("RowNumber");
-        COLUMN_ROW_NUMBER_CUSTOMER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_CUSTOMER.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMER_KEY_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_KEY_CUSTOMER.setName("CustomerKey");
-        COLUMN_CUSTOMER_KEY_CUSTOMER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_KEY_CUSTOMER.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_GEOGRAPHY_KEY_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GEOGRAPHY_KEY_CUSTOMER.setName("GeographyKey");
-        COLUMN_GEOGRAPHY_KEY_CUSTOMER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_GEOGRAPHY_KEY_CUSTOMER.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMER_ALTERNATE_KEY_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_ALTERNATE_KEY_CUSTOMER.setName("CustomerAlternateKey");
-        COLUMN_CUSTOMER_ALTERNATE_KEY_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CUSTOMER_ALTERNATE_KEY_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_FIRST_NAME_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FIRST_NAME_CUSTOMER.setName("FirstName");
-        COLUMN_FIRST_NAME_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_FIRST_NAME_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_MIDDLE_NAME_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MIDDLE_NAME_CUSTOMER.setName("MiddleName");
-        COLUMN_MIDDLE_NAME_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_MIDDLE_NAME_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_MIDDLE_NAME_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_LAST_NAME_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_LAST_NAME_CUSTOMER.setName("LastName");
-        COLUMN_LAST_NAME_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_LAST_NAME_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_NAME_STYLE_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_NAME_STYLE_CUSTOMER.setName("NameStyle");
-        COLUMN_NAME_STYLE_CUSTOMER.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_NAME_STYLE_CUSTOMER.setType(SQLSimpleTypes.Sql99.booleanType());
 
         COLUMN_BIRTH_DATE_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_BIRTH_DATE_CUSTOMER.setName("BirthDate");
-        COLUMN_BIRTH_DATE_CUSTOMER.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_BIRTH_DATE_CUSTOMER.setType(SQLSimpleTypes.Sql99.dateType());
 
         COLUMN_MARITAL_STATUS_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MARITAL_STATUS_CUSTOMER.setName("MaritalStatus");
-        COLUMN_MARITAL_STATUS_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_MARITAL_STATUS_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SUFFIX_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SUFFIX_CUSTOMER.setName("Suffix");
-        COLUMN_SUFFIX_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SUFFIX_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_SUFFIX_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_GENDER_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GENDER_CUSTOMER.setName("Gender");
-        COLUMN_GENDER_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_GENDER_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_EMAIL_ADDRESS_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EMAIL_ADDRESS_CUSTOMER.setName("EmailAddress");
-        COLUMN_EMAIL_ADDRESS_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_EMAIL_ADDRESS_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_YARLY_INCOME_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_YARLY_INCOME_CUSTOMER.setName("YearlyIncome");
-        COLUMN_YARLY_INCOME_CUSTOMER.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_YARLY_INCOME_CUSTOMER.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_TOTAL_CHILDREN_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TOTAL_CHILDREN_CUSTOMER.setName("TotalChildren");
-        COLUMN_TOTAL_CHILDREN_CUSTOMER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TOTAL_CHILDREN_CUSTOMER.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_NUMBER_CHILDREN_AT_HOME_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_NUMBER_CHILDREN_AT_HOME_CUSTOMER.setName("NumberChildrenAtHome");
-        COLUMN_NUMBER_CHILDREN_AT_HOME_CUSTOMER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_NUMBER_CHILDREN_AT_HOME_CUSTOMER.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_ENGLISH_EDUCATION_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ENGLISH_EDUCATION_CUSTOMER.setName("EnglishEducation");
-        COLUMN_ENGLISH_EDUCATION_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_ENGLISH_EDUCATION_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SPANISH_EDUCATION_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SPANISH_EDUCATION_CUSTOMER.setName("SpanishEducation");
-        COLUMN_SPANISH_EDUCATION_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SPANISH_EDUCATION_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_FRENCH_EDUCATION_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FRENCH_EDUCATION_CUSTOMER.setName("FrenchEducation");
-        COLUMN_FRENCH_EDUCATION_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_FRENCH_EDUCATION_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ENGLISH_OCCUPATION_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ENGLISH_OCCUPATION_CUSTOMER.setName("EnglishOccupation");
-        COLUMN_ENGLISH_OCCUPATION_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_ENGLISH_OCCUPATION_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SPANISH_OCCUPATION_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SPANISH_OCCUPATION_CUSTOMER.setName("SpanishOccupation");
-        COLUMN_SPANISH_OCCUPATION_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SPANISH_OCCUPATION_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_FRENCH_OCCUPATION_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FRENCH_OCCUPATION_CUSTOMER.setName("FrenchOccupation");
-        COLUMN_FRENCH_OCCUPATION_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_FRENCH_OCCUPATION_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_HOUSE_OWNER_FLAG_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_HOUSE_OWNER_FLAG_CUSTOMER.setName("HouseOwnerFlag");
-        COLUMN_HOUSE_OWNER_FLAG_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_HOUSE_OWNER_FLAG_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_NUMBER_CARS_OWNED_FLAG_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_NUMBER_CARS_OWNED_FLAG_CUSTOMER.setName("NumberCarsOwned");
-        COLUMN_NUMBER_CARS_OWNED_FLAG_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_NUMBER_CARS_OWNED_FLAG_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ADDRESS_LINE1_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ADDRESS_LINE1_CUSTOMER.setName("AddressLine1");
-        COLUMN_ADDRESS_LINE1_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_ADDRESS_LINE1_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ADDRESS_LINE2_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ADDRESS_LINE2_CUSTOMER.setName("AddressLine2");
-        COLUMN_ADDRESS_LINE2_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_ADDRESS_LINE2_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_ADDRESS_LINE2_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_PHONE_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PHONE_CUSTOMER.setName("Phone");
-        COLUMN_PHONE_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_PHONE_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_DATE_FIRST_PURCHASE_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DATE_FIRST_PURCHASE_CUSTOMER.setName("DateFirstPurchase");
-        COLUMN_DATE_FIRST_PURCHASE_CUSTOMER.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_DATE_FIRST_PURCHASE_CUSTOMER.setType(SQLSimpleTypes.Sql99.dateType());
 
         COLUMN_COMMUTE_DISTANCE_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COMMUTE_DISTANCE_CUSTOMER.setName("CommuteDistance");
-        COLUMN_COMMUTE_DISTANCE_CUSTOMER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_COMMUTE_DISTANCE_CUSTOMER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ROW_NUMBER_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_EMPLOYEE.setName("RowNumber");
-        COLUMN_ROW_NUMBER_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_EMPLOYEE_KEY_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EMPLOYEE_KEY_EMPLOYEE.setName("EmployeeKey");
-        COLUMN_EMPLOYEE_KEY_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_EMPLOYEE_KEY_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PARENT_EMPLOYEE_KEY_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PARENT_EMPLOYEE_KEY_EMPLOYEE.setName("ParentEmployeeKey");
-        COLUMN_PARENT_EMPLOYEE_KEY_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PARENT_EMPLOYEE_KEY_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_EMPLOYEE_NATIONAL_ID_ALTERNATE_KEY_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EMPLOYEE_NATIONAL_ID_ALTERNATE_KEY_EMPLOYEE.setName("EmployeeNationalIDAlternateKey");
-        COLUMN_EMPLOYEE_NATIONAL_ID_ALTERNATE_KEY_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_EMPLOYEE_NATIONAL_ID_ALTERNATE_KEY_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_PARENT_EMPLOYEE_NATIONAL_ID_ALTERNATE_KEY_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PARENT_EMPLOYEE_NATIONAL_ID_ALTERNATE_KEY_EMPLOYEE.setName("ParentEmployeeNationalIDAlternateKey");
-        COLUMN_PARENT_EMPLOYEE_NATIONAL_ID_ALTERNATE_KEY_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_PARENT_EMPLOYEE_NATIONAL_ID_ALTERNATE_KEY_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_PARENT_EMPLOYEE_NATIONAL_ID_ALTERNATE_KEY_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SALES_TERRITORY_KEY_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_TERRITORY_KEY_EMPLOYEE.setName("SalesTerritoryKey");
-        COLUMN_SALES_TERRITORY_KEY_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SALES_TERRITORY_KEY_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_SALES_TERRITORY_KEY_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_FIRST_NAME_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FIRST_NAME_EMPLOYEE.setName("FirstName");
-        COLUMN_FIRST_NAME_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_FIRST_NAME_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_LAST_NAME_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_LAST_NAME_EMPLOYEE.setName("LastName");
-        COLUMN_LAST_NAME_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_LAST_NAME_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_MIDDLE_NAME_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MIDDLE_NAME_EMPLOYEE.setName("MiddleName");
-        COLUMN_MIDDLE_NAME_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_MIDDLE_NAME_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_MIDDLE_NAME_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_NAME_STYLE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_NAME_STYLE_EMPLOYEE.setName("NameStyle");
-        COLUMN_NAME_STYLE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_NAME_STYLE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.booleanType());
 
         COLUMN_TITLE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TITLE_EMPLOYEE.setName("Title");
-        COLUMN_TITLE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_TITLE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_HIRE_DATE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_HIRE_DATE_EMPLOYEE.setName("HireDate");
-        COLUMN_HIRE_DATE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_HIRE_DATE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.dateType());
 
         COLUMN_BIRTH_DATE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_BIRTH_DATE_EMPLOYEE.setName("BirthDate");
-        COLUMN_BIRTH_DATE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_BIRTH_DATE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.dateType());
 
         COLUMN_LOGIN_ID_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_LOGIN_ID_EMPLOYEE.setName("LoginID");
-        COLUMN_LOGIN_ID_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_LOGIN_ID_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_EMAIL_ADDRESS_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EMAIL_ADDRESS_EMPLOYEE.setName("EmailAddress");
-        COLUMN_EMAIL_ADDRESS_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_EMAIL_ADDRESS_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_PHONE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PHONE_EMPLOYEE.setName("Phone");
-        COLUMN_PHONE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_PHONE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_MARITAL_STATUS_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MARITAL_STATUS_EMPLOYEE.setName("MaritalStatus");
-        COLUMN_MARITAL_STATUS_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_MARITAL_STATUS_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_EMERGENCY_CONTACT_NAME_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EMERGENCY_CONTACT_NAME_EMPLOYEE.setName("EmergencyContactName");
-        COLUMN_EMERGENCY_CONTACT_NAME_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_EMERGENCY_CONTACT_NAME_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_EMERGENCY_CONTACT_PHONE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EMERGENCY_CONTACT_PHONE_EMPLOYEE.setName("EmergencyContactPhone");
-        COLUMN_EMERGENCY_CONTACT_PHONE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_EMERGENCY_CONTACT_PHONE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SALARIED_FLAG_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALARIED_FLAG_EMPLOYEE.setName("SalariedFlag");
-        COLUMN_SALARIED_FLAG_EMPLOYEE.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_SALARIED_FLAG_EMPLOYEE.setType(SQLSimpleTypes.Sql99.booleanType());
 
         COLUMN_GENDER_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GENDER_EMPLOYEE.setName("Gender");
-        COLUMN_GENDER_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_GENDER_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_PAY_FREQUENCY_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PAY_FREQUENCY_EMPLOYEE.setName("PayFrequency");
-        COLUMN_PAY_FREQUENCY_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PAY_FREQUENCY_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_BASE_RATE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_BASE_RATE_EMPLOYEE.setName("BaseRate");
-        COLUMN_BASE_RATE_EMPLOYEE.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_BASE_RATE_EMPLOYEE.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_VACATION_HOURS_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_VACATION_HOURS_EMPLOYEE.setName("VacationHours");
-        COLUMN_VACATION_HOURS_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_VACATION_HOURS_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_SICK_LEAVE_HOURS_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SICK_LEAVE_HOURS_EMPLOYEE.setName("SickLeaveHours");
-        COLUMN_SICK_LEAVE_HOURS_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SICK_LEAVE_HOURS_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CURRENT_FLAG_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CURRENT_FLAG_EMPLOYEE.setName("CurrentFlag");
-        COLUMN_CURRENT_FLAG_EMPLOYEE.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_CURRENT_FLAG_EMPLOYEE.setType(SQLSimpleTypes.Sql99.booleanType());
 
         COLUMN_SALES_PERSONE_FLAG_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_PERSONE_FLAG_EMPLOYEE.setName("SalesPersonFlag");
-        COLUMN_SALES_PERSONE_FLAG_EMPLOYEE.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_SALES_PERSONE_FLAG_EMPLOYEE.setType(SQLSimpleTypes.Sql99.booleanType());
 
         COLUMN_DEPARTAMENT_NAME_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DEPARTAMENT_NAME_EMPLOYEE.setName("DepartmentName");
-        COLUMN_DEPARTAMENT_NAME_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_DEPARTAMENT_NAME_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_START_DATE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_START_DATE_EMPLOYEE.setName("StartDate");
-        COLUMN_START_DATE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_START_DATE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.dateType());
 
         COLUMN_END_DATE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_END_DATE_EMPLOYEE.setName("EndDate");
-        COLUMN_END_DATE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_END_DATE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.dateType());
         COLUMN_END_DATE_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STATUS_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STATUS_EMPLOYEE.setName("Status");
-        COLUMN_STATUS_EMPLOYEE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_STATUS_EMPLOYEE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ROW_NUMBER_GEOGRAPHY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_GEOGRAPHY.setName("RowNumber");
-        COLUMN_ROW_NUMBER_GEOGRAPHY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_GEOGRAPHY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_GEOGRAPHY_KEY_GEOGRAPHY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GEOGRAPHY_KEY_GEOGRAPHY.setName("GeographyKey");
-        COLUMN_GEOGRAPHY_KEY_GEOGRAPHY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_GEOGRAPHY_KEY_GEOGRAPHY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CITY_GEOGRAPHY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CITY_GEOGRAPHY.setName("City");
-        COLUMN_CITY_GEOGRAPHY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CITY_GEOGRAPHY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_STATE_PROVINCE_CODE_GEOGRAPHY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STATE_PROVINCE_CODE_GEOGRAPHY.setName("StateProvinceCode");
-        COLUMN_STATE_PROVINCE_CODE_GEOGRAPHY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_STATE_PROVINCE_CODE_GEOGRAPHY.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_STATE_PROVINCE_CODE_GEOGRAPHY.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STATE_PROVINCE_NAME_GEOGRAPHY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STATE_PROVINCE_NAME_GEOGRAPHY.setName("StateProvinceName");
-        COLUMN_STATE_PROVINCE_NAME_GEOGRAPHY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_STATE_PROVINCE_NAME_GEOGRAPHY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_COUNTRY_REGION_CODE_GEOGRAPHY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COUNTRY_REGION_CODE_GEOGRAPHY.setName("CountryRegionCode");
-        COLUMN_COUNTRY_REGION_CODE_GEOGRAPHY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_COUNTRY_REGION_CODE_GEOGRAPHY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ENGLISH_COUNTRY_REGION_NAME_GEOGRAPHY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ENGLISH_COUNTRY_REGION_NAME_GEOGRAPHY.setName("EnglishCountryRegionName");
-        COLUMN_ENGLISH_COUNTRY_REGION_NAME_GEOGRAPHY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_ENGLISH_COUNTRY_REGION_NAME_GEOGRAPHY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SPANISH_COUNTRY_REGION_NAME_GEOGRAPHY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SPANISH_COUNTRY_REGION_NAME_GEOGRAPHY.setName("SpanishCountryRegionName");
-        COLUMN_SPANISH_COUNTRY_REGION_NAME_GEOGRAPHY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SPANISH_COUNTRY_REGION_NAME_GEOGRAPHY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_FRENCH_COUNTRY_REGION_NAME_GEOGRAPHY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FRENCH_COUNTRY_REGION_NAME_GEOGRAPHY.setName("FrenchCountryRegionName");
-        COLUMN_FRENCH_COUNTRY_REGION_NAME_GEOGRAPHY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_FRENCH_COUNTRY_REGION_NAME_GEOGRAPHY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_POSTAL_CODE_GEOGRAPHY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_POSTAL_CODE_GEOGRAPHY.setName("PostalCode");
-        COLUMN_POSTAL_CODE_GEOGRAPHY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_POSTAL_CODE_GEOGRAPHY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SALES_TERRITORY_KEY_GEOGRAPHY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_TERRITORY_KEY_GEOGRAPHY.setName("SalesTerritoryKey");
-        COLUMN_SALES_TERRITORY_KEY_GEOGRAPHY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SALES_TERRITORY_KEY_GEOGRAPHY.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_SALES_TERRITORY_KEY_GEOGRAPHY.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_ROW_NUMBER_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_PRODUCT.setName("RowNumber");
-        COLUMN_ROW_NUMBER_PRODUCT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_PRODUCT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_KEY_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_KEY_PRODUCT.setName("ProductKey");
-        COLUMN_PRODUCT_KEY_PRODUCT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_KEY_PRODUCT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_ALTERNATE_KEY_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ALTERNATE_KEY_PRODUCT.setName("ProductAlternateKey");
-        COLUMN_PRODUCT_ALTERNATE_KEY_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_PRODUCT_ALTERNATE_KEY_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_PRODUCT_SUBCATEGORY_KEY_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_SUBCATEGORY_KEY_PRODUCT.setName("ProductSubcategoryKey");
-        COLUMN_PRODUCT_SUBCATEGORY_KEY_PRODUCT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_SUBCATEGORY_KEY_PRODUCT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_WEIGHT_UNIT_MEASURE_CODE_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WEIGHT_UNIT_MEASURE_CODE_PRODUCT.setName("WeightUnitMeasureCode");
-        COLUMN_WEIGHT_UNIT_MEASURE_CODE_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_WEIGHT_UNIT_MEASURE_CODE_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SIZE_UNIT_MEASURE_CODE_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SIZE_UNIT_MEASURE_CODE_PRODUCT.setName("SizeUnitMeasureCode");
-        COLUMN_SIZE_UNIT_MEASURE_CODE_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SIZE_UNIT_MEASURE_CODE_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ENGLISH_PRODUCT_NAME_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ENGLISH_PRODUCT_NAME_PRODUCT.setName("EnglishProductName");
-        COLUMN_ENGLISH_PRODUCT_NAME_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_ENGLISH_PRODUCT_NAME_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SPANISH_PRODUCT_NAME_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SPANISH_PRODUCT_NAME_PRODUCT.setName("SpanishProductName");
-        COLUMN_SPANISH_PRODUCT_NAME_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SPANISH_PRODUCT_NAME_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_FRENCH_PRODUCT_NAME_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FRENCH_PRODUCT_NAME_PRODUCT.setName("FrenchProductName");
-        COLUMN_FRENCH_PRODUCT_NAME_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_FRENCH_PRODUCT_NAME_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_STANDART_COST_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STANDART_COST_PRODUCT.setName("StandardCost");
-        COLUMN_STANDART_COST_PRODUCT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STANDART_COST_PRODUCT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_FINISH_GOODS_FLAG_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FINISH_GOODS_FLAG_PRODUCT.setName("FinishedGoodsFlag");
-        COLUMN_FINISH_GOODS_FLAG_PRODUCT.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_FINISH_GOODS_FLAG_PRODUCT.setType(SQLSimpleTypes.Sql99.booleanType());
 
         COLUMN_COLOR_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COLOR_PRODUCT.setName("Color");
-        COLUMN_COLOR_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_COLOR_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SAFETY_STOCK_LEVEL_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SAFETY_STOCK_LEVEL_PRODUCT.setName("SafetyStockLevel");
-        COLUMN_SAFETY_STOCK_LEVEL_PRODUCT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SAFETY_STOCK_LEVEL_PRODUCT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_REORDER_POINT_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_REORDER_POINT_PRODUCT.setName("ReorderPoint");
-        COLUMN_REORDER_POINT_PRODUCT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_REORDER_POINT_PRODUCT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_LIST_PRICE_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_LIST_PRICE_PRODUCT.setName("ListPrice");
-        COLUMN_LIST_PRICE_PRODUCT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_LIST_PRICE_PRODUCT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_SIZE_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SIZE_PRODUCT.setName("Size");
-        COLUMN_SIZE_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SIZE_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SIZE_RANGE_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SIZE_RANGE_PRODUCT.setName("SizeRange");
-        COLUMN_SIZE_RANGE_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SIZE_RANGE_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_SIZE_RANGE_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WEIGHT_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WEIGHT_PRODUCT.setName("Weight");
-        COLUMN_WEIGHT_PRODUCT.setType(SqlSimpleTypes.Sql99.doublePrecisionType());
+        COLUMN_WEIGHT_PRODUCT.setType(SQLSimpleTypes.Sql99.doublePrecisionType());
 
         COLUMN_DAYS_TO_MANUFACTURE_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DAYS_TO_MANUFACTURE_PRODUCT.setName("DaysToManufacture");
-        COLUMN_DAYS_TO_MANUFACTURE_PRODUCT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DAYS_TO_MANUFACTURE_PRODUCT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_LINE_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_LINE_PRODUCT.setName("ProductLine");
-        COLUMN_PRODUCT_LINE_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_PRODUCT_LINE_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_PRODUCT_LINE_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_DEALER_PRICE_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DEALER_PRICE_PRODUCT.setName("DealerPrice");
-        COLUMN_DEALER_PRICE_PRODUCT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_DEALER_PRICE_PRODUCT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_CLASS_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CLASS_PRODUCT.setName("Class");
-        COLUMN_CLASS_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CLASS_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_STYLE_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STYLE_PRODUCT.setName("Style");
-        COLUMN_STYLE_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_STYLE_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_MODEL_NAME_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MODEL_NAME_PRODUCT.setName("ModelName");
-        COLUMN_MODEL_NAME_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_MODEL_NAME_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ENGLISH_DESCRIPTION_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ENGLISH_DESCRIPTION_PRODUCT.setName("EnglishDescription");
-        COLUMN_ENGLISH_DESCRIPTION_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_ENGLISH_DESCRIPTION_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_FRENCH_DESCRIPTION_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FRENCH_DESCRIPTION_PRODUCT.setName("FrenchDescription");
-        COLUMN_FRENCH_DESCRIPTION_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_FRENCH_DESCRIPTION_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_CHINESE_DESCRIPTION_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CHINESE_DESCRIPTION_PRODUCT.setName("ChineseDescription");
-        COLUMN_CHINESE_DESCRIPTION_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CHINESE_DESCRIPTION_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ARABIC_DESCRIPTION_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ARABIC_DESCRIPTION_PRODUCT.setName("ArabicDescription");
-        COLUMN_ARABIC_DESCRIPTION_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_ARABIC_DESCRIPTION_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_HEBREW_DESCRIPTION_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_HEBREW_DESCRIPTION_PRODUCT.setName("HebrewDescription");
-        COLUMN_HEBREW_DESCRIPTION_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_HEBREW_DESCRIPTION_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_THAI_DESCRIPTION_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_THAI_DESCRIPTION_PRODUCT.setName("ThaiDescription");
-        COLUMN_THAI_DESCRIPTION_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_THAI_DESCRIPTION_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_START_DATE_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_START_DATE_PRODUCT.setName("StartDate");
-        COLUMN_START_DATE_PRODUCT.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_START_DATE_PRODUCT.setType(SQLSimpleTypes.Sql99.dateType());
 
         COLUMN_END_DATE_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_END_DATE_PRODUCT.setName("EndDate");
-        COLUMN_END_DATE_PRODUCT.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_END_DATE_PRODUCT.setType(SQLSimpleTypes.Sql99.dateType());
         COLUMN_END_DATE_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STATUS_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STATUS_PRODUCT.setName("Status");
-        COLUMN_STATUS_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_STATUS_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SUBCATEGORY_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SUBCATEGORY_PRODUCT.setName("Subcategory");
-        COLUMN_SUBCATEGORY_PRODUCT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SUBCATEGORY_PRODUCT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ROW_NUMBER_PRODUCT_CATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_PRODUCT_CATEGORY.setName("RowNumber");
-        COLUMN_ROW_NUMBER_PRODUCT_CATEGORY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_PRODUCT_CATEGORY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_CATEGORY_KEY_PRODUCT_CATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_CATEGORY_KEY_PRODUCT_CATEGORY.setName("ProductCategoryKey");
-        COLUMN_PRODUCT_CATEGORY_KEY_PRODUCT_CATEGORY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_CATEGORY_KEY_PRODUCT_CATEGORY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_ALTERNATE_KEY_PRODUCT_CATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ALTERNATE_KEY_PRODUCT_CATEGORY.setName("ProductCategoryAlternateKey");
-        COLUMN_PRODUCT_ALTERNATE_KEY_PRODUCT_CATEGORY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ALTERNATE_KEY_PRODUCT_CATEGORY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_ENGLISH_PRODUCT_CATEGORY_NAME_PRODUCT_CATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ENGLISH_PRODUCT_CATEGORY_NAME_PRODUCT_CATEGORY.setName("EnglishProductCategoryName");
-        COLUMN_ENGLISH_PRODUCT_CATEGORY_NAME_PRODUCT_CATEGORY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_ENGLISH_PRODUCT_CATEGORY_NAME_PRODUCT_CATEGORY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SPANISH_PRODUCT_CATEGORY_NAME_PRODUCT_CATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SPANISH_PRODUCT_CATEGORY_NAME_PRODUCT_CATEGORY.setName("SpanishProductCategoryName");
-        COLUMN_SPANISH_PRODUCT_CATEGORY_NAME_PRODUCT_CATEGORY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SPANISH_PRODUCT_CATEGORY_NAME_PRODUCT_CATEGORY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_FRENCH_PRODUCT_CATEGORY_NAME_PRODUCT_CATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FRENCH_PRODUCT_CATEGORY_NAME_PRODUCT_CATEGORY.setName("FrenchProductCategoryName");
-        COLUMN_FRENCH_PRODUCT_CATEGORY_NAME_PRODUCT_CATEGORY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_FRENCH_PRODUCT_CATEGORY_NAME_PRODUCT_CATEGORY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ROW_NUMBER_PRODUCT_SUBCATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_PRODUCT_SUBCATEGORY.setName("RowNumber");
-        COLUMN_ROW_NUMBER_PRODUCT_SUBCATEGORY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_PRODUCT_SUBCATEGORY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_SUBCATEGORY_KEY_PRODUCT_SUBCATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_SUBCATEGORY_KEY_PRODUCT_SUBCATEGORY.setName("ProductSubcategoryKey");
-        COLUMN_PRODUCT_SUBCATEGORY_KEY_PRODUCT_SUBCATEGORY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_SUBCATEGORY_KEY_PRODUCT_SUBCATEGORY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_ALTERNATE_KEY_PRODUCT_SUBCATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ALTERNATE_KEY_PRODUCT_SUBCATEGORY.setName("ProductSubcategoryAlternateKey");
-        COLUMN_PRODUCT_ALTERNATE_KEY_PRODUCT_SUBCATEGORY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ALTERNATE_KEY_PRODUCT_SUBCATEGORY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_ENGLISH_PRODUCT_SUBCATEGORY_NAME_PRODUCT_SUBCATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ENGLISH_PRODUCT_SUBCATEGORY_NAME_PRODUCT_SUBCATEGORY.setName("EnglishProductSubcategoryName");
-        COLUMN_ENGLISH_PRODUCT_SUBCATEGORY_NAME_PRODUCT_SUBCATEGORY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_ENGLISH_PRODUCT_SUBCATEGORY_NAME_PRODUCT_SUBCATEGORY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SPANISH_PRODUCT_SUBCATEGORY_NAME_PRODUCT_SUBCATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SPANISH_PRODUCT_SUBCATEGORY_NAME_PRODUCT_SUBCATEGORY.setName("SpanishProductSubcategoryName");
-        COLUMN_SPANISH_PRODUCT_SUBCATEGORY_NAME_PRODUCT_SUBCATEGORY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SPANISH_PRODUCT_SUBCATEGORY_NAME_PRODUCT_SUBCATEGORY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_FRENCH_PRODUCT_SUBCATEGORY_NAME_PRODUCT_SUBCATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FRENCH_PRODUCT_SUBCATEGORY_NAME_PRODUCT_SUBCATEGORY.setName("FrenchProductSubcategoryName");
-        COLUMN_FRENCH_PRODUCT_SUBCATEGORY_NAME_PRODUCT_SUBCATEGORY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_FRENCH_PRODUCT_SUBCATEGORY_NAME_PRODUCT_SUBCATEGORY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_PRODUCT_CATEGORY_KEY_PRODUCT_SUBCATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_CATEGORY_KEY_PRODUCT_SUBCATEGORY.setName("ProductCategoryKey");
-        COLUMN_PRODUCT_CATEGORY_KEY_PRODUCT_SUBCATEGORY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_CATEGORY_KEY_PRODUCT_SUBCATEGORY.setType(SQLSimpleTypes.Sql99.integerType());
 
         //"RowNumber","StoreKey","Geography_Key","StoreName","Number_of_Employees","Sales"
         //INTEGER,INTEGER,INTEGER,VARCHAR,INTEGER,DECIMAL(19.4)
         COLUMN_ROW_NUMBER_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_STORE.setName("RowNumber");
-        COLUMN_ROW_NUMBER_STORE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_STORE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_KEY_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_KEY_STORE.setName("StoreKey");
-        COLUMN_STORE_KEY_STORE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_KEY_STORE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_GEOGRAPHY_KEY_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GEOGRAPHY_KEY_STORE.setName("Geography_Key");
-        COLUMN_GEOGRAPHY_KEY_STORE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_GEOGRAPHY_KEY_STORE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_NAME_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_NAME_STORE.setName("StoreName");
-        COLUMN_STORE_NAME_STORE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_STORE_NAME_STORE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_NUMBER_OF_EMPLOYEES_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_NUMBER_OF_EMPLOYEES_STORE.setName("Number_of_Employees");
-        COLUMN_NUMBER_OF_EMPLOYEES_STORE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_NUMBER_OF_EMPLOYEES_STORE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_SALES_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_STORE.setName("Sales");
-        COLUMN_SALES_STORE.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_SALES_STORE.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_ROW_NUMBER_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_TIME.setName("RowNumber");
-        COLUMN_ROW_NUMBER_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_TIME_KEY_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_KEY_TIME.setName("TimeKey");
-        COLUMN_TIME_KEY_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_KEY_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_FULL_DATE_ALTERNATE_KEY_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FULL_DATE_ALTERNATE_KEY_TIME.setName("FullDateAlternateKey");
-        COLUMN_FULL_DATE_ALTERNATE_KEY_TIME.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_FULL_DATE_ALTERNATE_KEY_TIME.setType(SQLSimpleTypes.Sql99.dateType());
 
         COLUMN_DAY_NUMBER_OF_WEEK_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DAY_NUMBER_OF_WEEK_TIME.setName("DayNumberOfWeek");
-        COLUMN_DAY_NUMBER_OF_WEEK_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DAY_NUMBER_OF_WEEK_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_ENGLISH_DAY_NAME_OF_WEEK_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ENGLISH_DAY_NAME_OF_WEEK_TIME.setName("EnglishDayNameOfWeek");
-        COLUMN_ENGLISH_DAY_NAME_OF_WEEK_TIME.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_ENGLISH_DAY_NAME_OF_WEEK_TIME.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SPANISH_DAY_NAME_OF_WEEK_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SPANISH_DAY_NAME_OF_WEEK_TIME.setName("SpanishDayNameOfWeek");
-        COLUMN_SPANISH_DAY_NAME_OF_WEEK_TIME.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SPANISH_DAY_NAME_OF_WEEK_TIME.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_FRENCH_DAY_NAME_OF_WEEK_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FRENCH_DAY_NAME_OF_WEEK_TIME.setName("FrenchDayNameOfWeek");
-        COLUMN_FRENCH_DAY_NAME_OF_WEEK_TIME.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_FRENCH_DAY_NAME_OF_WEEK_TIME.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_DAY_NUMBER_OF_MONTH_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DAY_NUMBER_OF_MONTH_TIME.setName("DayNumberOfMonth");
-        COLUMN_DAY_NUMBER_OF_MONTH_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DAY_NUMBER_OF_MONTH_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DAY_NUMBER_OF_YEAR_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DAY_NUMBER_OF_YEAR_TIME.setName("DayNumberOfYear");
-        COLUMN_DAY_NUMBER_OF_YEAR_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DAY_NUMBER_OF_YEAR_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_WEEK_NUMBER_OF_YEAR_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WEEK_NUMBER_OF_YEAR_TIME.setName("WeekNumberOfYear");
-        COLUMN_WEEK_NUMBER_OF_YEAR_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_WEEK_NUMBER_OF_YEAR_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_ENGLISH_MONTH_NAME_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ENGLISH_MONTH_NAME_TIME.setName("EnglishMonthName");
-        COLUMN_ENGLISH_MONTH_NAME_TIME.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_ENGLISH_MONTH_NAME_TIME.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SPANISH_MONTH_NAME_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SPANISH_MONTH_NAME_TIME.setName("SpanishMonthName");
-        COLUMN_SPANISH_MONTH_NAME_TIME.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SPANISH_MONTH_NAME_TIME.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_FRENCH_MONTH_NAME_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FRENCH_MONTH_NAME_TIME.setName("FrenchMonthName");
-        COLUMN_FRENCH_MONTH_NAME_TIME.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_FRENCH_MONTH_NAME_TIME.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_MONTH_NUMBER_OF_YEAR_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MONTH_NUMBER_OF_YEAR_TIME.setName("MonthNumberOfYear");
-        COLUMN_MONTH_NUMBER_OF_YEAR_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_MONTH_NUMBER_OF_YEAR_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CALENDAR_QUARTER_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CALENDAR_QUARTER_TIME.setName("CalendarQuarter");
-        COLUMN_CALENDAR_QUARTER_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CALENDAR_QUARTER_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CALENDAR_YEAR_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CALENDAR_YEAR_TIME.setName("CalendarYear");
-        COLUMN_CALENDAR_YEAR_TIME.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CALENDAR_YEAR_TIME.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_CALENDAR_SEMESTER_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CALENDAR_SEMESTER_TIME.setName("CalendarSemester");
-        COLUMN_CALENDAR_SEMESTER_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CALENDAR_SEMESTER_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_FISCAL_QUARTER_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FISCAL_QUARTER_TIME.setName("FiscalQuarter");
-        COLUMN_FISCAL_QUARTER_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FISCAL_QUARTER_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_FISCAL_YEAR_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FISCAL_YEAR_TIME.setName("FiscalYear");
-        COLUMN_FISCAL_YEAR_TIME.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_FISCAL_YEAR_TIME.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_FISCAL_SEMESTER_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FISCAL_SEMESTER_TIME.setName("FiscalSemester");
-        COLUMN_FISCAL_SEMESTER_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FISCAL_SEMESTER_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         TABLE_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         TABLE_CUSTOMER.setName("Customer");

--- a/instance/emf/complex/csdl/bikeshop/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/csdl/bikeshop/CatalogSupplier.java
+++ b/instance/emf/complex/csdl/bikeshop/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/csdl/bikeshop/CatalogSupplier.java
@@ -49,7 +49,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.enumerations.NullableType;
 @MappingInstance(kind = Kind.COMPLEX, source = Source.EMF, number = "99.1.7", group = "Full Examples")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
@@ -251,248 +251,248 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
     static {
         COLUMN_ROW_NUMBER_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_BIKE_SALES.setName("RowNumber");
-        COLUMN_ROW_NUMBER_BIKE_SALES.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_BIKE_SALES.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_SALES_ORDER_NUMBER_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_ORDER_NUMBER_BIKE_SALES.setName("SalesOrderNumber");
-        COLUMN_SALES_ORDER_NUMBER_BIKE_SALES.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SALES_ORDER_NUMBER_BIKE_SALES.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SALES_ORDER_LINE_NUMBER_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_ORDER_LINE_NUMBER_BIKE_SALES.setName("SalesOrderLineNumber");
-        COLUMN_SALES_ORDER_LINE_NUMBER_BIKE_SALES.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SALES_ORDER_LINE_NUMBER_BIKE_SALES.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_REVISION_NUMBER_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_REVISION_NUMBER_BIKE_SALES.setName("RevisionNumber");
-        COLUMN_REVISION_NUMBER_BIKE_SALES.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_REVISION_NUMBER_BIKE_SALES.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_KEY_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_KEY_BIKE_SALES.setName("ProductKey");
-        COLUMN_PRODUCT_KEY_BIKE_SALES.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_KEY_BIKE_SALES.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_COUNTRY_CODE_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COUNTRY_CODE_BIKE_SALES.setName("CountryCode");
-        COLUMN_COUNTRY_CODE_BIKE_SALES.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_COUNTRY_CODE_BIKE_SALES.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_CURENCY_KEY_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CURENCY_KEY_BIKE_SALES.setName("CurrencyKey");
-        COLUMN_CURENCY_KEY_BIKE_SALES.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CURENCY_KEY_BIKE_SALES.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CALENDAR_QUARTER_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CALENDAR_QUARTER_BIKE_SALES.setName("CalendarQuarter");
-        COLUMN_CALENDAR_QUARTER_BIKE_SALES.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CALENDAR_QUARTER_BIKE_SALES.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SALES_CHANNEL_CODE_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_CHANNEL_CODE_BIKE_SALES.setName("SalesChannelCode");
-        COLUMN_SALES_CHANNEL_CODE_BIKE_SALES.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SALES_CHANNEL_CODE_BIKE_SALES.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ORDER_QUANTITY_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ORDER_QUANTITY_BIKE_SALES.setName("OrderQuantity");
-        COLUMN_ORDER_QUANTITY_BIKE_SALES.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ORDER_QUANTITY_BIKE_SALES.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_UNIT_PRICE_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_PRICE_BIKE_SALES.setName("UnitPrice");
-        COLUMN_UNIT_PRICE_BIKE_SALES.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_UNIT_PRICE_BIKE_SALES.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_EXTENDED_AMOUNT_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EXTENDED_AMOUNT_BIKE_SALES.setName("ExtendedAmount");
-        COLUMN_EXTENDED_AMOUNT_BIKE_SALES.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_EXTENDED_AMOUNT_BIKE_SALES.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_UNIT_PRICE_DISCOUNT_PCT_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_PRICE_DISCOUNT_PCT_BIKE_SALES.setName("UnitPriceDiscountPct");
-        COLUMN_UNIT_PRICE_DISCOUNT_PCT_BIKE_SALES.setType(SqlSimpleTypes.Sql99.doublePrecisionType());
+        COLUMN_UNIT_PRICE_DISCOUNT_PCT_BIKE_SALES.setType(SQLSimpleTypes.Sql99.doublePrecisionType());
 
         COLUMN_DISCOUNT_AMOUNT_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DISCOUNT_AMOUNT_BIKE_SALES.setName("DiscountAmount");
-        COLUMN_DISCOUNT_AMOUNT_BIKE_SALES.setType(SqlSimpleTypes.Sql99.doublePrecisionType());
+        COLUMN_DISCOUNT_AMOUNT_BIKE_SALES.setType(SQLSimpleTypes.Sql99.doublePrecisionType());
 
         COLUMN_PRODUCT_STANDART_COST_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_STANDART_COST_BIKE_SALES.setName("ProductStandardCost");
-        COLUMN_PRODUCT_STANDART_COST_BIKE_SALES.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_PRODUCT_STANDART_COST_BIKE_SALES.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_TOTAL_PRODUCT_COST_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TOTAL_PRODUCT_COST_BIKE_SALES.setName("TotalProductCost");
-        COLUMN_TOTAL_PRODUCT_COST_BIKE_SALES.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_TOTAL_PRODUCT_COST_BIKE_SALES.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_SALES_AMOUNT_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_AMOUNT_BIKE_SALES.setName("SalesAmount");
-        COLUMN_SALES_AMOUNT_BIKE_SALES.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_SALES_AMOUNT_BIKE_SALES.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_TAX_AMT_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TAX_AMT_BIKE_SALES.setName("TaxAmt");
-        COLUMN_TAX_AMT_BIKE_SALES.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_TAX_AMT_BIKE_SALES.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_FREIGHT_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FREIGHT_BIKE_SALES.setName("Freight");
-        COLUMN_FREIGHT_BIKE_SALES.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_FREIGHT_BIKE_SALES.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_CARRIER_TRACKING_NUMBER_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CARRIER_TRACKING_NUMBER_BIKE_SALES.setName("CarrierTrackingNumber");
-        COLUMN_CARRIER_TRACKING_NUMBER_BIKE_SALES.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CARRIER_TRACKING_NUMBER_BIKE_SALES.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_CARRIER_TRACKING_NUMBER_BIKE_SALES.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_CUSTOMER_PO_NUMBER_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_PO_NUMBER_BIKE_SALES.setName("CustomerPONumber");
-        COLUMN_CUSTOMER_PO_NUMBER_BIKE_SALES.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CUSTOMER_PO_NUMBER_BIKE_SALES.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_CUSTOMER_PO_NUMBER_BIKE_SALES.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_CUSTOMER_ACCOUNT_NUMBER_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_ACCOUNT_NUMBER_BIKE_SALES.setName("CustomerAccountNumber");
-        COLUMN_CUSTOMER_ACCOUNT_NUMBER_BIKE_SALES.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CUSTOMER_ACCOUNT_NUMBER_BIKE_SALES.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ROW_NUMBER_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_BIKE.setName("RowNumber");
-        COLUMN_ROW_NUMBER_BIKE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_BIKE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_KEY_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_KEY_BIKE.setName("ProductKey");
-        COLUMN_PRODUCT_KEY_BIKE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_KEY_BIKE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_ALTERNATE_KEY_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ALTERNATE_KEY_BIKE.setName("ProductAlternateKey");
-        COLUMN_PRODUCT_ALTERNATE_KEY_BIKE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_PRODUCT_ALTERNATE_KEY_BIKE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_PRODUCT_SUBCATEGORY_KEY_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_SUBCATEGORY_KEY_BIKE.setName("ProductSubcategoryKey");
-        COLUMN_PRODUCT_SUBCATEGORY_KEY_BIKE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_SUBCATEGORY_KEY_BIKE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_NAME_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_NAME_BIKE.setName("ProductName");
-        COLUMN_PRODUCT_NAME_BIKE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_PRODUCT_NAME_BIKE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_STARDART_COST_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STARDART_COST_BIKE.setName("StandardCost");
-        COLUMN_STARDART_COST_BIKE.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STARDART_COST_BIKE.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_FINISHED_GOODS_FLAG_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FINISHED_GOODS_FLAG_BIKE.setName("FinishedGoodsFlag");
-        COLUMN_FINISHED_GOODS_FLAG_BIKE.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_FINISHED_GOODS_FLAG_BIKE.setType(SQLSimpleTypes.Sql99.booleanType());
 
         COLUMN_COLOR_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COLOR_BIKE.setName("Color");
-        COLUMN_COLOR_BIKE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_COLOR_BIKE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_LIST_PRICE_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_LIST_PRICE_BIKE.setName("ListPrice");
-        COLUMN_LIST_PRICE_BIKE.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_LIST_PRICE_BIKE.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_SIZE_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SIZE_BIKE.setName("Size");
-        COLUMN_SIZE_BIKE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SIZE_BIKE.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_SIZE_BIKE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SIZE_RANGE_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SIZE_RANGE_BIKE.setName("SizeRange");
-        COLUMN_SIZE_RANGE_BIKE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SIZE_RANGE_BIKE.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_SIZE_RANGE_BIKE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WIGHT_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WIGHT_BIKE.setName("Weight");
-        COLUMN_WIGHT_BIKE.setType(SqlSimpleTypes.Sql99.doublePrecisionType());
+        COLUMN_WIGHT_BIKE.setType(SQLSimpleTypes.Sql99.doublePrecisionType());
 
         COLUMN_DEALER_PRICE_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DEALER_PRICE_BIKE.setName("DealerPrice");
-        COLUMN_DEALER_PRICE_BIKE.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_DEALER_PRICE_BIKE.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_CLASS_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CLASS_BIKE.setName("Class");
-        COLUMN_CLASS_BIKE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CLASS_BIKE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_STYLE_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STYLE_BIKE.setName("Style");
-        COLUMN_STYLE_BIKE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_STYLE_BIKE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_MODEL_NAME_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MODEL_NAME_BIKE.setName("ModelName");
-        COLUMN_MODEL_NAME_BIKE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_MODEL_NAME_BIKE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_DESCRIPTION_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DESCRIPTION_BIKE.setName("Description");
-        COLUMN_DESCRIPTION_BIKE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_DESCRIPTION_BIKE.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_DESCRIPTION_BIKE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WEIGHT_UNIT_MEASURE_CODE_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WEIGHT_UNIT_MEASURE_CODE_BIKE.setName("WeightUnitMeasureCode");
-        COLUMN_WEIGHT_UNIT_MEASURE_CODE_BIKE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_WEIGHT_UNIT_MEASURE_CODE_BIKE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SIZE_UNIT_MEASURE_CODE_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SIZE_UNIT_MEASURE_CODE_BIKE.setName("SizeUnitMeasureCode");
-        COLUMN_SIZE_UNIT_MEASURE_CODE_BIKE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SIZE_UNIT_MEASURE_CODE_BIKE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_SAFETY_STOCK_LEVEL_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SAFETY_STOCK_LEVEL_BIKE.setName("SafetyStockLevel");
-        COLUMN_SAFETY_STOCK_LEVEL_BIKE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SAFETY_STOCK_LEVEL_BIKE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_REORDER_POINT_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_REORDER_POINT_BIKE.setName("ReorderPoint");
-        COLUMN_REORDER_POINT_BIKE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_REORDER_POINT_BIKE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DAYS_TO_MANUFACTURE_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DAYS_TO_MANUFACTURE_BIKE.setName("DaysToManufacture");
-        COLUMN_DAYS_TO_MANUFACTURE_BIKE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DAYS_TO_MANUFACTURE_BIKE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_LINE_BIKE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_LINE_BIKE.setName("ProductLine");
-        COLUMN_PRODUCT_LINE_BIKE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_PRODUCT_LINE_BIKE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ROW_NUMBER_BIKE_SUBCATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_BIKE_SUBCATEGORY.setName("RowNumber");
-        COLUMN_ROW_NUMBER_BIKE_SUBCATEGORY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_BIKE_SUBCATEGORY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_SUBCATEGORY_KEY_BIKE_SUBCATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_SUBCATEGORY_KEY_BIKE_SUBCATEGORY.setName("ProductSubcategoryKey");
-        COLUMN_PRODUCT_SUBCATEGORY_KEY_BIKE_SUBCATEGORY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_SUBCATEGORY_KEY_BIKE_SUBCATEGORY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_SUBCATEGORY_BIKE_SUBCATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SUBCATEGORY_BIKE_SUBCATEGORY.setName("Subcategory");
-        COLUMN_SUBCATEGORY_BIKE_SUBCATEGORY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SUBCATEGORY_BIKE_SUBCATEGORY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ROW_NUMBER_CALENDAR_QUARTER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_CALENDAR_QUARTER.setName("RowNumber");
-        COLUMN_ROW_NUMBER_CALENDAR_QUARTER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_CALENDAR_QUARTER.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CALENDAR_QUARTER2_CALENDAR_QUARTER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CALENDAR_QUARTER2_CALENDAR_QUARTER.setName("CalendarQuarter2");
-        COLUMN_CALENDAR_QUARTER2_CALENDAR_QUARTER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CALENDAR_QUARTER2_CALENDAR_QUARTER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ROW_NUMBER_COUNTRY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_COUNTRY.setName("RowNumber");
-        COLUMN_ROW_NUMBER_COUNTRY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_COUNTRY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_COUNTRY_CODE_COUNTRY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COUNTRY_CODE_COUNTRY.setName("CountryCode");
-        COLUMN_COUNTRY_CODE_COUNTRY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_COUNTRY_CODE_COUNTRY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_COUNTRY_NAME_COUNTRY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COUNTRY_NAME_COUNTRY.setName("CountryName");
-        COLUMN_COUNTRY_NAME_COUNTRY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_COUNTRY_NAME_COUNTRY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ROW_NUMBER_CURRENCY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_CURRENCY.setName("RowNumber");
-        COLUMN_ROW_NUMBER_CURRENCY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_CURRENCY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CURRENCY_KEY_CURRENCY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CURRENCY_KEY_CURRENCY.setName("CurrencyKey");
-        COLUMN_CURRENCY_KEY_CURRENCY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CURRENCY_KEY_CURRENCY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CURRENCY_ALTERNATE_KEY_CURRENCY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CURRENCY_ALTERNATE_KEY_CURRENCY.setName("CurrencyAlternateKey");
-        COLUMN_CURRENCY_ALTERNATE_KEY_CURRENCY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CURRENCY_ALTERNATE_KEY_CURRENCY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_CURRENCY_NAME_CURRENCY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CURRENCY_NAME_CURRENCY.setName("CurrencyName");
-        COLUMN_CURRENCY_NAME_CURRENCY.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CURRENCY_NAME_CURRENCY.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_ROW_NUMBER_SALES_CHANNEL = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ROW_NUMBER_SALES_CHANNEL.setName("RowNumber");
-        COLUMN_ROW_NUMBER_SALES_CHANNEL.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ROW_NUMBER_SALES_CHANNEL.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_SALES_CHANNEL_CODE_SALES_CHANNEL = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_CHANNEL_CODE_SALES_CHANNEL.setName("SalesChannelCode");
-        COLUMN_SALES_CHANNEL_CODE_SALES_CHANNEL.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SALES_CHANNEL_CODE_SALES_CHANNEL.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SALES_CHANNEL_NAME_SALES_CHANNEL = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_CHANNEL_NAME_SALES_CHANNEL.setName("SalesChannelName");
-        COLUMN_SALES_CHANNEL_NAME_SALES_CHANNEL.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_SALES_CHANNEL_NAME_SALES_CHANNEL.setType(SQLSimpleTypes.Sql99.varcharType());
 
         TABLE_BIKE_SALES = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         TABLE_BIKE_SALES.setName("BikeSales");

--- a/instance/emf/complex/expressivenames/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/expressivenames/CatalogSupplier.java
+++ b/instance/emf/complex/expressivenames/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/expressivenames/CatalogSupplier.java
@@ -21,6 +21,8 @@ import org.eclipse.daanse.rolap.mapping.instance.api.MappingInstance;
 import org.eclipse.daanse.rolap.mapping.instance.api.Source;
 import org.eclipse.daanse.rolap.mapping.model.catalog.Catalog;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import static org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLIndexes.index;
+
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ExplicitHierarchy;
@@ -50,7 +52,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.COMPLEX, source = Source.EMF, number = "99.1.2", group = "Full Examples")
 @Component(service = CatalogMappingSupplier.class, scope = ServiceScope.PROTOTYPE)
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -213,164 +215,164 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         // Initialize columns - Fact table
         COLUMN_D1_CUBE1FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D1_CUBE1FACT.setName("D1");
-        COLUMN_D1_CUBE1FACT.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_D1_CUBE1FACT.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_D2_CUBE1FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D2_CUBE1FACT.setName("D2");
-        COLUMN_D2_CUBE1FACT.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_D2_CUBE1FACT.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_D3_CUBE1FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3_CUBE1FACT.setName("D3");
-        COLUMN_D3_CUBE1FACT.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_D3_CUBE1FACT.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_M1_CUBE1FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_M1_CUBE1FACT.setName("M1");
-        COLUMN_M1_CUBE1FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_M1_CUBE1FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Initialize columns - D1H1L1 table
         COLUMN_D1H1L1_D1H1L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D1H1L1_D1H1L1TABLE.setName(D_1_H_1_L_1);
-        COLUMN_D1H1L1_D1H1L1TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D1H1L1_D1H1L1TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D1H1L1_NAME_D1H1L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D1H1L1_NAME_D1H1L1TABLE.setName("D1H1L1_NAME");
-        COLUMN_D1H1L1_NAME_D1H1L1TABLE.setType(SqlSimpleTypes.varcharType(255));
+        COLUMN_D1H1L1_NAME_D1H1L1TABLE.setType(SQLSimpleTypes.varcharType(255));
 
         COLUMN_D1H1L1_ORDINAL_D1H1L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D1H1L1_ORDINAL_D1H1L1TABLE.setName("D1H1L1_Ordinal");
-        COLUMN_D1H1L1_ORDINAL_D1H1L1TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D1H1L1_ORDINAL_D1H1L1TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Initialize columns - D2H1L1 table
         COLUMN_D2H1L1_D2H1L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D2H1L1_D2H1L1TABLE.setName(D_2_H_1_L_1);
-        COLUMN_D2H1L1_D2H1L1TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D2H1L1_D2H1L1TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D2H1L1_NAME_D2H1L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D2H1L1_NAME_D2H1L1TABLE.setName("D2H1L1_NAME");
-        COLUMN_D2H1L1_NAME_D2H1L1TABLE.setType(SqlSimpleTypes.varcharType(255));
+        COLUMN_D2H1L1_NAME_D2H1L1TABLE.setType(SQLSimpleTypes.varcharType(255));
 
         COLUMN_D2H1L1_ORDINAL_D2H1L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D2H1L1_ORDINAL_D2H1L1TABLE.setName("D2H1L1_Ordinal");
-        COLUMN_D2H1L1_ORDINAL_D2H1L1TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D2H1L1_ORDINAL_D2H1L1TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Initialize columns - D2H2L2 table
         COLUMN_D2H2L2_D2H2L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D2H2L2_D2H2L2TABLE.setName(D_2_H_2_L_2);
-        COLUMN_D2H2L2_D2H2L2TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D2H2L2_D2H2L2TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D2H2L1_D2H2L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D2H2L1_D2H2L2TABLE.setName("D2H2L1");
-        COLUMN_D2H2L1_D2H2L2TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D2H2L1_D2H2L2TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D2H2L2_NAME_D2H2L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D2H2L2_NAME_D2H2L2TABLE.setName("D2H2L2_NAME");
-        COLUMN_D2H2L2_NAME_D2H2L2TABLE.setType(SqlSimpleTypes.varcharType(255));
+        COLUMN_D2H2L2_NAME_D2H2L2TABLE.setType(SQLSimpleTypes.varcharType(255));
 
         COLUMN_D2H2L1_NAME_D2H2L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D2H2L1_NAME_D2H2L2TABLE.setName("D2H2L1_NAME");
-        COLUMN_D2H2L1_NAME_D2H2L2TABLE.setType(SqlSimpleTypes.varcharType(255));
+        COLUMN_D2H2L1_NAME_D2H2L2TABLE.setType(SQLSimpleTypes.varcharType(255));
 
         COLUMN_D2H2L2_ORDINAL_D2H2L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D2H2L2_ORDINAL_D2H2L2TABLE.setName("D2H2L2_Ordinal");
-        COLUMN_D2H2L2_ORDINAL_D2H2L2TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D2H2L2_ORDINAL_D2H2L2TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D2H2L1_ORDINAL_D2H2L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D2H2L1_ORDINAL_D2H2L2TABLE.setName("D2H2L1_Ordinal");
-        COLUMN_D2H2L1_ORDINAL_D2H2L2TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D2H2L1_ORDINAL_D2H2L2TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Initialize columns - D3H1L1 table
         COLUMN_D3H1L1_D3H1L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H1L1_D3H1L1TABLE.setName(D_3_H_1_L_1);
-        COLUMN_D3H1L1_D3H1L1TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H1L1_D3H1L1TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D3H1L1_NAME_D3H1L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H1L1_NAME_D3H1L1TABLE.setName("D3H1L1_NAME");
-        COLUMN_D3H1L1_NAME_D3H1L1TABLE.setType(SqlSimpleTypes.varcharType(255));
+        COLUMN_D3H1L1_NAME_D3H1L1TABLE.setType(SQLSimpleTypes.varcharType(255));
 
         COLUMN_D3H1L1_ORDINAL_D3H1L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H1L1_ORDINAL_D3H1L1TABLE.setName("D3H1L1_Ordinal");
-        COLUMN_D3H1L1_ORDINAL_D3H1L1TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H1L1_ORDINAL_D3H1L1TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Initialize columns - D3H2L2 table
         COLUMN_D3H2L2_D3H2L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H2L2_D3H2L2TABLE.setName(D_3_H_2_L_2);
-        COLUMN_D3H2L2_D3H2L2TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H2L2_D3H2L2TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D3H2L2_ID_D3H2L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H2L2_ID_D3H2L2TABLE.setName("D3H2L2_id");
-        COLUMN_D3H2L2_ID_D3H2L2TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H2L2_ID_D3H2L2TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D3H2L1_ID_D3H2L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H2L1_ID_D3H2L2TABLE.setName("D3H2L1_id");
-        COLUMN_D3H2L1_ID_D3H2L2TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H2L1_ID_D3H2L2TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D3H2L2_NAME_D3H2L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H2L2_NAME_D3H2L2TABLE.setName("D3H2L2_NAME");
-        COLUMN_D3H2L2_NAME_D3H2L2TABLE.setType(SqlSimpleTypes.varcharType(255));
+        COLUMN_D3H2L2_NAME_D3H2L2TABLE.setType(SQLSimpleTypes.varcharType(255));
 
         COLUMN_D3H2L2_ORDINAL_D3H2L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H2L2_ORDINAL_D3H2L2TABLE.setName("D3H2L2_Ordinal");
-        COLUMN_D3H2L2_ORDINAL_D3H2L2TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H2L2_ORDINAL_D3H2L2TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Initialize columns - D3H2L1 table
         COLUMN_D3H2L1_D3H2L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H2L1_D3H2L1TABLE.setName(D_3_H_2_L_1);
-        COLUMN_D3H2L1_D3H2L1TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H2L1_D3H2L1TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D3H2L1_NAME_D3H2L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H2L1_NAME_D3H2L1TABLE.setName("D3H2L1_NAME");
-        COLUMN_D3H2L1_NAME_D3H2L1TABLE.setType(SqlSimpleTypes.varcharType(255));
+        COLUMN_D3H2L1_NAME_D3H2L1TABLE.setType(SQLSimpleTypes.varcharType(255));
 
         COLUMN_D3H2L1_ORDINAL_D3H2L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H2L1_ORDINAL_D3H2L1TABLE.setName("D3H2L1_Ordinal");
-        COLUMN_D3H2L1_ORDINAL_D3H2L1TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H2L1_ORDINAL_D3H2L1TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Initialize columns - D3H3L3 table
         COLUMN_D3H3L3_D3H3L3TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H3L3_D3H3L3TABLE.setName(D_3_H_3_L_3);
-        COLUMN_D3H3L3_D3H3L3TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H3L3_D3H3L3TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D3H3L2_ID_D3H3L3TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H3L2_ID_D3H3L3TABLE.setName("D3H3L2_id");
-        COLUMN_D3H3L2_ID_D3H3L3TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H3L2_ID_D3H3L3TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D3H3L3_NAME_D3H3L3TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H3L3_NAME_D3H3L3TABLE.setName("D3H3L3_NAME");
-        COLUMN_D3H3L3_NAME_D3H3L3TABLE.setType(SqlSimpleTypes.varcharType(255));
+        COLUMN_D3H3L3_NAME_D3H3L3TABLE.setType(SQLSimpleTypes.varcharType(255));
 
         COLUMN_D3H3L3_ORDINAL_D3H3L3TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H3L3_ORDINAL_D3H3L3TABLE.setName("D3H3L3_Ordinal");
-        COLUMN_D3H3L3_ORDINAL_D3H3L3TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H3L3_ORDINAL_D3H3L3TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Initialize columns - D3H3L2 table
         COLUMN_D3H3L2_D3H3L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H3L2_D3H3L2TABLE.setName(D_3_H_3_L_2);
-        COLUMN_D3H3L2_D3H3L2TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H3L2_D3H3L2TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D3H3L1_ID_D3H3L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H3L1_ID_D3H3L2TABLE.setName("D3H3L1_id");
-        COLUMN_D3H3L1_ID_D3H3L2TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H3L1_ID_D3H3L2TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D3H3L2_NAME_D3H3L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H3L2_NAME_D3H3L2TABLE.setName("D3H3L2_NAME");
-        COLUMN_D3H3L2_NAME_D3H3L2TABLE.setType(SqlSimpleTypes.varcharType(255));
+        COLUMN_D3H3L2_NAME_D3H3L2TABLE.setType(SQLSimpleTypes.varcharType(255));
 
         COLUMN_D3H3L2_ORDINAL_D3H3L2TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H3L2_ORDINAL_D3H3L2TABLE.setName("D3H3L2_Ordinal");
-        COLUMN_D3H3L2_ORDINAL_D3H3L2TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H3L2_ORDINAL_D3H3L2TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Initialize columns - D3H3L1 table
         COLUMN_D3H3L1_D3H3L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H3L1_D3H3L1TABLE.setName(D_3_H_3_L_1);
-        COLUMN_D3H3L1_D3H3L1TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H3L1_D3H3L1TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_D3H3L1_NAME_D3H3L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H3L1_NAME_D3H3L1TABLE.setName("D3H3L1_NAME");
-        COLUMN_D3H3L1_NAME_D3H3L1TABLE.setType(SqlSimpleTypes.varcharType(255));
+        COLUMN_D3H3L1_NAME_D3H3L1TABLE.setType(SQLSimpleTypes.varcharType(255));
 
         COLUMN_D3H3L1_ORDINAL_D3H3L1TABLE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_D3H3L1_ORDINAL_D3H3L1TABLE.setName("D3H3L1_Ordinal");
-        COLUMN_D3H3L1_ORDINAL_D3H3L1TABLE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_D3H3L1_ORDINAL_D3H3L1TABLE.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Initialize tables
         TABLE_CUBE1FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
@@ -718,21 +720,4 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
                 List.of(new CatalogRef("catalog", this::get)));
     }
 
-    /**
-     * One SQL index over {@code columns} of {@code table}. These describe the
-     * database the dataset ships, not anything the mapping reads.
-     */
-    private static org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLIndex index(String name, boolean unique, org.eclipse.daanse.cwm.model.cwm.resource.relational.Table table,
-            org.eclipse.daanse.cwm.model.cwm.resource.relational.Column... columns) {
-        org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLIndex idx = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createSQLIndex();
-        idx.setName(name);
-        idx.setIsUnique(unique);
-        idx.setSpannedClass(table);
-        for (org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column : columns) {
-            org.eclipse.daanse.cwm.model.cwm.foundation.keysindexes.IndexedFeature feature = org.eclipse.daanse.cwm.model.cwm.foundation.keysindexes.KeysindexesFactory.eINSTANCE.createIndexedFeature();
-            feature.setFeature(column);
-            idx.getIndexedFeature().add(feature);
-        }
-        return idx;
-    }
 }

--- a/instance/emf/complex/foodmart/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/foodmart/CatalogSupplier.java
+++ b/instance/emf/complex/foodmart/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/foodmart/CatalogSupplier.java
@@ -37,6 +37,8 @@ import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Cal
 import org.eclipse.daanse.rolap.mapping.model.catalog.Catalog;
 import org.eclipse.daanse.rolap.mapping.model.access.common.CatalogAccess;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import static org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLIndexes.index;
+
 import org.eclipse.daanse.rolap.mapping.model.database.relational.ColumnInternalDataType;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.CountMeasure;
 import org.eclipse.daanse.rolap.mapping.model.access.olap.CubeAccess;
@@ -86,7 +88,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.enumerations.NullableType;
 @MappingInstance(kind = Kind.COMPLEX, source = Source.EMF, number = "99.1.4", group = "Full Examples")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
@@ -1340,912 +1342,912 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         COLUMN_TIME_ID_SALESFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_SALESFACT.setName("time_id");
-        COLUMN_TIME_ID_SALESFACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_ID_SALESFACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_ID_SALESFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_ID_SALESFACT.setName("store_id");
-        COLUMN_STORE_ID_SALESFACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_ID_SALESFACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMER_ID_SALESFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_ID_SALESFACT.setName("customer_id");
-        COLUMN_CUSTOMER_ID_SALESFACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_ID_SALESFACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PROMOTION_ID_SALESFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PROMOTION_ID_SALESFACT.setName("promotion_id");
-        COLUMN_PROMOTION_ID_SALESFACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PROMOTION_ID_SALESFACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_ID_SALESFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ID_SALESFACT.setName("product_id");
-        COLUMN_PRODUCT_ID_SALESFACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ID_SALESFACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_UNIT_SALES_SALESFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_SALESFACT.setName("unit_sales");
-        COLUMN_UNIT_SALES_SALESFACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_UNIT_SALES_SALESFACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_STORE_SALES_SALESFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_SALESFACT.setName("store_sales");
-        COLUMN_STORE_SALES_SALESFACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_SALES_SALESFACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_STORE_COST_SALESFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_SALESFACT.setName("store_cost");
-        COLUMN_STORE_COST_SALESFACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_COST_SALESFACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_PRODUCT_ID_SALESFACT1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ID_SALESFACT1998.setName("product_id");
-        COLUMN_PRODUCT_ID_SALESFACT1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ID_SALESFACT1998.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_TIME_ID_SALESFACT1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_SALESFACT1998.setName("time_id");
-        COLUMN_TIME_ID_SALESFACT1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_ID_SALESFACT1998.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMER_ID_SALESFACT1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_ID_SALESFACT1998.setName("customer_id");
-        COLUMN_CUSTOMER_ID_SALESFACT1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_ID_SALESFACT1998.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PROMOTION_ID_SALESFACT1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PROMOTION_ID_SALESFACT1998.setName("promotion_id");
-        COLUMN_PROMOTION_ID_SALESFACT1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PROMOTION_ID_SALESFACT1998.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_ID_SALESFACT1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_ID_SALESFACT1998.setName("store_id");
-        COLUMN_STORE_ID_SALESFACT1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_ID_SALESFACT1998.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_SALES_SALESFACT1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_SALESFACT1998.setName("store_sales");
-        COLUMN_STORE_SALES_SALESFACT1998.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_SALES_SALESFACT1998.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_STORE_COST_SALESFACT1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_SALESFACT1998.setName("store_cost");
-        COLUMN_STORE_COST_SALESFACT1998.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_COST_SALESFACT1998.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_UNIT_SALES_SALESFACT1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_SALESFACT1998.setName("unit_sales");
-        COLUMN_UNIT_SALES_SALESFACT1998.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_UNIT_SALES_SALESFACT1998.setType(SQLSimpleTypes.decimalType(18, 4));
 
         // Time table columns
         COLUMN_TIME_ID_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_TIME.setName("time_id");
-        COLUMN_TIME_ID_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_ID_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_THE_DATE_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_THE_DATE_TIME.setName("the_date");
-        COLUMN_THE_DATE_TIME.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_THE_DATE_TIME.setType(SQLSimpleTypes.Sql99.dateType());
         COLUMN_THE_DATE_TIME.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_THE_YEAR_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_THE_YEAR_TIME.setName("the_year");
-        COLUMN_THE_YEAR_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_THE_YEAR_TIME.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_THE_YEAR_TIME.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_QUARTER_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_QUARTER_TIME.setName("quarter");
-        COLUMN_QUARTER_TIME.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_QUARTER_TIME.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_QUARTER_TIME.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_THE_MONTH_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_THE_MONTH_TIME.setName("the_month");
-        COLUMN_THE_MONTH_TIME.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_THE_MONTH_TIME.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_THE_MONTH_TIME.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Store table columns
         COLUMN_STORE_ID_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_ID_STORE.setName("store_id");
-        COLUMN_STORE_ID_STORE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_ID_STORE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_NAME_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_NAME_STORE.setName("store_name");
-        COLUMN_STORE_NAME_STORE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_NAME_STORE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_NAME_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_COUNTRY_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COUNTRY_STORE.setName("store_country");
-        COLUMN_STORE_COUNTRY_STORE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_COUNTRY_STORE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_COUNTRY_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_STATE_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_STATE_STORE.setName("store_state");
-        COLUMN_STORE_STATE_STORE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_STATE_STORE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_STATE_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_CITY_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_CITY_STORE.setName("store_city");
-        COLUMN_STORE_CITY_STORE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_CITY_STORE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_CITY_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Customer table columns
         COLUMN_CUSTOMER_ID_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_ID_CUSTOMER.setName("customer_id");
-        COLUMN_CUSTOMER_ID_CUSTOMER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_ID_CUSTOMER.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_FULLNAME_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FULLNAME_CUSTOMER.setName("fullname");
-        COLUMN_FULLNAME_CUSTOMER.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_FULLNAME_CUSTOMER.setType(SQLSimpleTypes.varcharType(60));
 
         COLUMN_GENDER_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GENDER_CUSTOMER.setName("gender");
-        COLUMN_GENDER_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_GENDER_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_COUNTRY_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COUNTRY_CUSTOMER.setName("country");
-        COLUMN_COUNTRY_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_COUNTRY_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_STATE_PROVINCE_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STATE_PROVINCE_CUSTOMER.setName("state_province");
-        COLUMN_STATE_PROVINCE_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STATE_PROVINCE_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STATE_PROVINCE_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_CITY_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CITY_CUSTOMER.setName("city");
-        COLUMN_CITY_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_CITY_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_CITY_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_LNAME_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_LNAME_CUSTOMER.setName("lname");
-        COLUMN_LNAME_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_LNAME_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_FNAME_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FNAME_CUSTOMER.setName("fname");
-        COLUMN_FNAME_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_FNAME_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_ACCOUNT_NUM_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ACCOUNT_NUM_CUSTOMER.setName("account_num");
-        COLUMN_ACCOUNT_NUM_CUSTOMER.setType(SqlSimpleTypes.bigintType());
+        COLUMN_ACCOUNT_NUM_CUSTOMER.setType(SQLSimpleTypes.bigintType());
 
         COLUMN_CUSTOMER_REGION_ID_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_REGION_ID_CUSTOMER.setName("customer_region_id");
-        COLUMN_CUSTOMER_REGION_ID_CUSTOMER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_REGION_ID_CUSTOMER.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_NUM_CARS_OWNED_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_NUM_CARS_OWNED_CUSTOMER.setName("num_cars_owned");
-        COLUMN_NUM_CARS_OWNED_CUSTOMER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_NUM_CARS_OWNED_CUSTOMER.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_NUM_CARS_OWNED_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_TOTAL_CHILDREN_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TOTAL_CHILDREN_CUSTOMER.setName("total_children");
-        COLUMN_TOTAL_CHILDREN_CUSTOMER.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_TOTAL_CHILDREN_CUSTOMER.setType(SQLSimpleTypes.Sql99.smallintType());
 
         COLUMN_ADDRESS2_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ADDRESS2_CUSTOMER.setName("address2");
-        COLUMN_ADDRESS2_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_ADDRESS2_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_ADDRESS2_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Product table columns
         COLUMN_PRODUCT_CLASS_ID_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_CLASS_ID_PRODUCT.setName("product_class_id");
-        COLUMN_PRODUCT_CLASS_ID_PRODUCT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_CLASS_ID_PRODUCT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_ID_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ID_PRODUCT.setName("product_id");
-        COLUMN_PRODUCT_ID_PRODUCT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ID_PRODUCT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_NAME_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_NAME_PRODUCT.setName("product_name");
-        COLUMN_PRODUCT_NAME_PRODUCT.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_PRODUCT_NAME_PRODUCT.setType(SQLSimpleTypes.varcharType(60));
 
         COLUMN_BRAND_NAME_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_BRAND_NAME_PRODUCT.setName("brand_name");
-        COLUMN_BRAND_NAME_PRODUCT.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_BRAND_NAME_PRODUCT.setType(SQLSimpleTypes.varcharType(60));
         COLUMN_BRAND_NAME_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SKU_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SKU_PRODUCT.setName("SKU");
-        COLUMN_SKU_PRODUCT.setType(SqlSimpleTypes.bigintType());
+        COLUMN_SKU_PRODUCT.setType(SQLSimpleTypes.bigintType());
 
         COLUMN_SRP_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SRP_PRODUCT.setName("SRP");
-        COLUMN_SRP_PRODUCT.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_SRP_PRODUCT.setType(SQLSimpleTypes.decimalType(10, 4));
         COLUMN_SRP_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_GROSS_WEIGHT_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GROSS_WEIGHT_PRODUCT.setName("gross_weight");
-        COLUMN_GROSS_WEIGHT_PRODUCT.setType(SqlSimpleTypes.Sql99.realType());
+        COLUMN_GROSS_WEIGHT_PRODUCT.setType(SQLSimpleTypes.Sql99.realType());
         COLUMN_GROSS_WEIGHT_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_NET_WEIGHT_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_NET_WEIGHT_PRODUCT.setName("net_weight");
-        COLUMN_NET_WEIGHT_PRODUCT.setType(SqlSimpleTypes.Sql99.realType());
+        COLUMN_NET_WEIGHT_PRODUCT.setType(SQLSimpleTypes.Sql99.realType());
         COLUMN_NET_WEIGHT_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_RECYCLABLE_PACKAGE_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_RECYCLABLE_PACKAGE_PRODUCT.setName("recyclable_package");
-        COLUMN_RECYCLABLE_PACKAGE_PRODUCT.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_RECYCLABLE_PACKAGE_PRODUCT.setType(SQLSimpleTypes.Sql99.booleanType());
         COLUMN_RECYCLABLE_PACKAGE_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_LOW_FAT_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_LOW_FAT_PRODUCT.setName("low_fat");
-        COLUMN_LOW_FAT_PRODUCT.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_LOW_FAT_PRODUCT.setType(SQLSimpleTypes.Sql99.booleanType());
         COLUMN_LOW_FAT_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_UNITS_PER_CASE_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNITS_PER_CASE_PRODUCT.setName("units_per_case");
-        COLUMN_UNITS_PER_CASE_PRODUCT.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_UNITS_PER_CASE_PRODUCT.setType(SQLSimpleTypes.Sql99.smallintType());
         COLUMN_UNITS_PER_CASE_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_CASES_PER_PALLET_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CASES_PER_PALLET_PRODUCT.setName("cases_per_pallet");
-        COLUMN_CASES_PER_PALLET_PRODUCT.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_CASES_PER_PALLET_PRODUCT.setType(SQLSimpleTypes.Sql99.smallintType());
         COLUMN_CASES_PER_PALLET_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SHELF_WIDTH_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SHELF_WIDTH_PRODUCT.setName("shelf_width");
-        COLUMN_SHELF_WIDTH_PRODUCT.setType(SqlSimpleTypes.Sql99.realType());
+        COLUMN_SHELF_WIDTH_PRODUCT.setType(SQLSimpleTypes.Sql99.realType());
         COLUMN_SHELF_WIDTH_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SHELF_HEIGHT_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SHELF_HEIGHT_PRODUCT.setName("shelf_height");
-        COLUMN_SHELF_HEIGHT_PRODUCT.setType(SqlSimpleTypes.Sql99.realType());
+        COLUMN_SHELF_HEIGHT_PRODUCT.setType(SQLSimpleTypes.Sql99.realType());
         COLUMN_SHELF_HEIGHT_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SHELF_DEPTH_PRODUCT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SHELF_DEPTH_PRODUCT.setName("shelf_depth");
-        COLUMN_SHELF_DEPTH_PRODUCT.setType(SqlSimpleTypes.Sql99.realType());
+        COLUMN_SHELF_DEPTH_PRODUCT.setType(SQLSimpleTypes.Sql99.realType());
         COLUMN_SHELF_DEPTH_PRODUCT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Initialize warehouse columns
         COLUMN_WAREHOUSE_ID_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_ID_WAREHOUSE.setName("warehouse_id");
-        COLUMN_WAREHOUSE_ID_WAREHOUSE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_WAREHOUSE_ID_WAREHOUSE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_WAREHOUSE_NAME_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_NAME_WAREHOUSE.setName("warehouse_name");
-        COLUMN_WAREHOUSE_NAME_WAREHOUSE.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_WAREHOUSE_NAME_WAREHOUSE.setType(SQLSimpleTypes.varcharType(60));
         COLUMN_WAREHOUSE_NAME_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WAREHOUSE_CITY_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_CITY_WAREHOUSE.setName("warehouse_city");
-        COLUMN_WAREHOUSE_CITY_WAREHOUSE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_WAREHOUSE_CITY_WAREHOUSE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_WAREHOUSE_CITY_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WAREHOUSE_STATE_PROVINCE_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_STATE_PROVINCE_WAREHOUSE.setName("warehouse_state_province");
-        COLUMN_WAREHOUSE_STATE_PROVINCE_WAREHOUSE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_WAREHOUSE_STATE_PROVINCE_WAREHOUSE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_WAREHOUSE_STATE_PROVINCE_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WAREHOUSE_COUNTRY_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_COUNTRY_WAREHOUSE.setName("warehouse_country");
-        COLUMN_WAREHOUSE_COUNTRY_WAREHOUSE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_WAREHOUSE_COUNTRY_WAREHOUSE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_WAREHOUSE_COUNTRY_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORES_ID_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORES_ID_WAREHOUSE.setName("stores_id");
-        COLUMN_STORES_ID_WAREHOUSE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORES_ID_WAREHOUSE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_STORES_ID_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Initialize inventory fact columns
         COLUMN_WAREHOUSE_ID_INVENTORY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_ID_INVENTORY_FACT.setName("warehouse_id");
-        COLUMN_WAREHOUSE_ID_INVENTORY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_WAREHOUSE_ID_INVENTORY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_WAREHOUSE_ID_INVENTORY_FACT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_ID_INVENTORY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_ID_INVENTORY_FACT.setName("store_id");
-        COLUMN_STORE_ID_INVENTORY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_ID_INVENTORY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_STORE_ID_INVENTORY_FACT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_PRODUCT_ID_INVENTORY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ID_INVENTORY_FACT.setName("product_id");
-        COLUMN_PRODUCT_ID_INVENTORY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ID_INVENTORY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_TIME_ID_INVENTORY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_INVENTORY_FACT.setName("time_id");
-        COLUMN_TIME_ID_INVENTORY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_ID_INVENTORY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_TIME_ID_INVENTORY_FACT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_INVOICE_INVENTORY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_INVOICE_INVENTORY_FACT.setName("store_invoice");
-        COLUMN_STORE_INVOICE_INVENTORY_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_INVOICE_INVENTORY_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
         COLUMN_STORE_INVOICE_INVENTORY_FACT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SUPPLY_TIME_INVENTORY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SUPPLY_TIME_INVENTORY_FACT.setName("supply_time");
-        COLUMN_SUPPLY_TIME_INVENTORY_FACT.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_SUPPLY_TIME_INVENTORY_FACT.setType(SQLSimpleTypes.Sql99.smallintType());
         COLUMN_SUPPLY_TIME_INVENTORY_FACT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WAREHOUSE_COST_INVENTORY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_COST_INVENTORY_FACT.setName("warehouse_cost");
-        COLUMN_WAREHOUSE_COST_INVENTORY_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_WAREHOUSE_COST_INVENTORY_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
         COLUMN_WAREHOUSE_COST_INVENTORY_FACT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WAREHOUSE_SALES_INVENTORY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_SALES_INVENTORY_FACT.setName("warehouse_sales");
-        COLUMN_WAREHOUSE_SALES_INVENTORY_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_WAREHOUSE_SALES_INVENTORY_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
         COLUMN_WAREHOUSE_SALES_INVENTORY_FACT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_UNITS_SHIPPED_INVENTORY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNITS_SHIPPED_INVENTORY_FACT.setName("units_shipped");
-        COLUMN_UNITS_SHIPPED_INVENTORY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_UNITS_SHIPPED_INVENTORY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_UNITS_SHIPPED_INVENTORY_FACT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_UNITS_ORDERED_INVENTORY_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNITS_ORDERED_INVENTORY_FACT.setName("units_ordered");
-        COLUMN_UNITS_ORDERED_INVENTORY_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_UNITS_ORDERED_INVENTORY_FACT.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_UNITS_ORDERED_INVENTORY_FACT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Initialize promotion columns
         COLUMN_PROMOTION_ID_PROMOTION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PROMOTION_ID_PROMOTION.setName("promotion_id");
-        COLUMN_PROMOTION_ID_PROMOTION.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PROMOTION_ID_PROMOTION.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PROMOTION_NAME_PROMOTION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PROMOTION_NAME_PROMOTION.setName("promotion_name");
-        COLUMN_PROMOTION_NAME_PROMOTION.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_PROMOTION_NAME_PROMOTION.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_PROMOTION_NAME_PROMOTION.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_MEDIA_TYPE_PROMOTION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MEDIA_TYPE_PROMOTION.setName("media_type");
-        COLUMN_MEDIA_TYPE_PROMOTION.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_MEDIA_TYPE_PROMOTION.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_MEDIA_TYPE_PROMOTION.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Initialize employee columns
         COLUMN_EMPLOYEE_ID_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EMPLOYEE_ID_EMPLOYEE.setName("employee_id");
-        COLUMN_EMPLOYEE_ID_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_EMPLOYEE_ID_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_FIRST_NAME_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FIRST_NAME_EMPLOYEE.setName("first_name");
-        COLUMN_FIRST_NAME_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_FIRST_NAME_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_LAST_NAME_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_LAST_NAME_EMPLOYEE.setName("last_name");
-        COLUMN_LAST_NAME_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_LAST_NAME_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_FULL_NAME_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FULL_NAME_EMPLOYEE.setName("full_name");
-        COLUMN_FULL_NAME_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_FULL_NAME_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_MANAGEMENT_ROLE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MANAGEMENT_ROLE_EMPLOYEE.setName("management_role");
-        COLUMN_MANAGEMENT_ROLE_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_MANAGEMENT_ROLE_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_MANAGEMENT_ROLE_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_POSITION_ID_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_POSITION_ID_EMPLOYEE.setName("position_id");
-        COLUMN_POSITION_ID_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_POSITION_ID_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_POSITION_ID_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_POSITION_TITLE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_POSITION_TITLE_EMPLOYEE.setName("position_title");
-        COLUMN_POSITION_TITLE_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_POSITION_TITLE_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_POSITION_TITLE_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_ID_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_ID_EMPLOYEE.setName("store_id");
-        COLUMN_STORE_ID_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_ID_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_SUPERVISOR_ID_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SUPERVISOR_ID_EMPLOYEE.setName("supervisor_id");
-        COLUMN_SUPERVISOR_ID_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SUPERVISOR_ID_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_SUPERVISOR_ID_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_MARITAL_STATUS_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MARITAL_STATUS_EMPLOYEE.setName("marital_status");
-        COLUMN_MARITAL_STATUS_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_MARITAL_STATUS_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_GENDER_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GENDER_EMPLOYEE.setName("gender");
-        COLUMN_GENDER_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_GENDER_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_SALARY_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALARY_EMPLOYEE.setName("salary");
-        COLUMN_SALARY_EMPLOYEE.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_SALARY_EMPLOYEE.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_EDUCATION_LEVEL_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EDUCATION_LEVEL_EMPLOYEE.setName("education_level");
-        COLUMN_EDUCATION_LEVEL_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_EDUCATION_LEVEL_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
 
         // Initialize department columns
         COLUMN_DEPARTMENT_ID_DEPARTMENT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DEPARTMENT_ID_DEPARTMENT.setName("department_id");
-        COLUMN_DEPARTMENT_ID_DEPARTMENT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DEPARTMENT_ID_DEPARTMENT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DEPARTMENT_DESCRIPTION_DEPARTMENT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DEPARTMENT_DESCRIPTION_DEPARTMENT.setName("department_description");
-        COLUMN_DEPARTMENT_DESCRIPTION_DEPARTMENT.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_DEPARTMENT_DESCRIPTION_DEPARTMENT.setType(SQLSimpleTypes.varcharType(30));
 
         // Initialize position columns
         COLUMN_POSITION_ID_POSITION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_POSITION_ID_POSITION.setName("position_id");
-        COLUMN_POSITION_ID_POSITION.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_POSITION_ID_POSITION.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_POSITION_ID_POSITION.setIsNullable(NullableType.COLUMN_NO_NULLS);
 
         COLUMN_POSITION_TITLE_POSITION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_POSITION_TITLE_POSITION.setName("position_title");
-        COLUMN_POSITION_TITLE_POSITION.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_POSITION_TITLE_POSITION.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_POSITION_TITLE_POSITION.setIsNullable(NullableType.COLUMN_NO_NULLS);
 
         COLUMN_PAY_TYPE_POSITION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PAY_TYPE_POSITION.setName("pay_type");
-        COLUMN_PAY_TYPE_POSITION.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_PAY_TYPE_POSITION.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_MIN_SCALE_POSITION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MIN_SCALE_POSITION.setName("min_scale");
-        COLUMN_MIN_SCALE_POSITION.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_MIN_SCALE_POSITION.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_MAX_SCALE_POSITION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MAX_SCALE_POSITION.setName("max_scale");
-        COLUMN_MAX_SCALE_POSITION.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_MAX_SCALE_POSITION.setType(SQLSimpleTypes.decimalType(18, 4));
 
         // Initialize salary columns
         COLUMN_EMPLOYEE_ID_SALARY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EMPLOYEE_ID_SALARY.setName("employee_id");
-        COLUMN_EMPLOYEE_ID_SALARY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_EMPLOYEE_ID_SALARY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DEPARTMENT_ID_SALARY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DEPARTMENT_ID_SALARY.setName("department_id");
-        COLUMN_DEPARTMENT_ID_SALARY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DEPARTMENT_ID_SALARY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CURRENCY_ID_SALARY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CURRENCY_ID_SALARY.setName("currency_id");
-        COLUMN_CURRENCY_ID_SALARY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CURRENCY_ID_SALARY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PAY_DATE_SALARY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PAY_DATE_SALARY.setName("pay_date");
-        COLUMN_PAY_DATE_SALARY.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_PAY_DATE_SALARY.setType(SQLSimpleTypes.Sql99.timestampType());
 
         COLUMN_SALARY_PAID_SALARY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALARY_PAID_SALARY.setName("salary_paid");
-        COLUMN_SALARY_PAID_SALARY.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_SALARY_PAID_SALARY.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_OVERTIME_PAID_SALARY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_OVERTIME_PAID_SALARY.setName("overtime_paid");
-        COLUMN_OVERTIME_PAID_SALARY.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_OVERTIME_PAID_SALARY.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_VACATION_ACCRUED_SALARY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_VACATION_ACCRUED_SALARY.setName("vacation_accrued");
-        COLUMN_VACATION_ACCRUED_SALARY.setType(SqlSimpleTypes.Sql99.realType());
+        COLUMN_VACATION_ACCRUED_SALARY.setType(SQLSimpleTypes.Sql99.realType());
 
         COLUMN_VACATION_USED_SALARY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_VACATION_USED_SALARY.setName("vacation_used");
-        COLUMN_VACATION_USED_SALARY.setType(SqlSimpleTypes.Sql99.realType());
+        COLUMN_VACATION_USED_SALARY.setType(SQLSimpleTypes.Sql99.realType());
 
         // Initialize employee closure columns
         COLUMN_SUPERVISOR_ID_EMPLOYEE_CLOSURE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SUPERVISOR_ID_EMPLOYEE_CLOSURE.setName("supervisor_id");
-        COLUMN_SUPERVISOR_ID_EMPLOYEE_CLOSURE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SUPERVISOR_ID_EMPLOYEE_CLOSURE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_SUPERVISOR_ID_EMPLOYEE_CLOSURE.setIsNullable(NullableType.COLUMN_NO_NULLS);
 
         COLUMN_EMPLOYEE_ID_EMPLOYEE_CLOSURE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EMPLOYEE_ID_EMPLOYEE_CLOSURE.setName("employee_id");
-        COLUMN_EMPLOYEE_ID_EMPLOYEE_CLOSURE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_EMPLOYEE_ID_EMPLOYEE_CLOSURE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DISTANCE_EMPLOYEE_CLOSURE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DISTANCE_EMPLOYEE_CLOSURE.setName("distance");
-        COLUMN_DISTANCE_EMPLOYEE_CLOSURE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DISTANCE_EMPLOYEE_CLOSURE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_DISTANCE_EMPLOYEE_CLOSURE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Initialize product class columns
         COLUMN_PRODUCT_CLASS_ID_PRODUCT_CLASS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_CLASS_ID_PRODUCT_CLASS.setName("product_class_id");
-        COLUMN_PRODUCT_CLASS_ID_PRODUCT_CLASS.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_CLASS_ID_PRODUCT_CLASS.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_SUBCATEGORY_PRODUCT_CLASS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_SUBCATEGORY_PRODUCT_CLASS.setName("product_subcategory");
-        COLUMN_PRODUCT_SUBCATEGORY_PRODUCT_CLASS.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_PRODUCT_SUBCATEGORY_PRODUCT_CLASS.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_PRODUCT_SUBCATEGORY_PRODUCT_CLASS.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_PRODUCT_CATEGORY_PRODUCT_CLASS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_CATEGORY_PRODUCT_CLASS.setName("product_category");
-        COLUMN_PRODUCT_CATEGORY_PRODUCT_CLASS.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_PRODUCT_CATEGORY_PRODUCT_CLASS.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_PRODUCT_CATEGORY_PRODUCT_CLASS.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_PRODUCT_DEPARTMENT_PRODUCT_CLASS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_DEPARTMENT_PRODUCT_CLASS.setName("product_department");
-        COLUMN_PRODUCT_DEPARTMENT_PRODUCT_CLASS.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_PRODUCT_DEPARTMENT_PRODUCT_CLASS.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_PRODUCT_DEPARTMENT_PRODUCT_CLASS.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_PRODUCT_FAMILY_PRODUCT_CLASS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_FAMILY_PRODUCT_CLASS.setName("product_family");
-        COLUMN_PRODUCT_FAMILY_PRODUCT_CLASS.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_PRODUCT_FAMILY_PRODUCT_CLASS.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_PRODUCT_FAMILY_PRODUCT_CLASS.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Initialize enhanced customer columns
         COLUMN_MARITAL_STATUS_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MARITAL_STATUS_CUSTOMER.setName("marital_status");
-        COLUMN_MARITAL_STATUS_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_MARITAL_STATUS_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_EDUCATION_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EDUCATION_CUSTOMER.setName("education");
-        COLUMN_EDUCATION_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_EDUCATION_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_YEARLY_INCOME_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_YEARLY_INCOME_CUSTOMER.setName("yearly_income");
-        COLUMN_YEARLY_INCOME_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_YEARLY_INCOME_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_MEMBER_CARD_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MEMBER_CARD_CUSTOMER.setName("member_card");
-        COLUMN_MEMBER_CARD_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_MEMBER_CARD_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_MEMBER_CARD_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_OCCUPATION_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_OCCUPATION_CUSTOMER.setName("occupation");
-        COLUMN_OCCUPATION_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_OCCUPATION_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_OCCUPATION_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_HOUSEOWNER_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_HOUSEOWNER_CUSTOMER.setName("houseowner");
-        COLUMN_HOUSEOWNER_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_HOUSEOWNER_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_HOUSEOWNER_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_NUM_CHILDREN_AT_HOME_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_NUM_CHILDREN_AT_HOME_CUSTOMER.setName("num_children_at_home");
-        COLUMN_NUM_CHILDREN_AT_HOME_CUSTOMER.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_NUM_CHILDREN_AT_HOME_CUSTOMER.setType(SQLSimpleTypes.Sql99.smallintType());
 
         // Initialize enhanced store columns
         COLUMN_STORE_TYPE_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_TYPE_STORE.setName("store_type");
-        COLUMN_STORE_TYPE_STORE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_TYPE_STORE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_TYPE_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_REGION_ID_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_REGION_ID_STORE.setName("region_id");
-        COLUMN_REGION_ID_STORE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_REGION_ID_STORE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_REGION_ID_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_STREET_ADDRESS_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_STREET_ADDRESS_STORE.setName("store_street_address");
-        COLUMN_STORE_STREET_ADDRESS_STORE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_STREET_ADDRESS_STORE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_STREET_ADDRESS_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_MANAGER_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_MANAGER_STORE.setName("store_manager");
-        COLUMN_STORE_MANAGER_STORE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_MANAGER_STORE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_MANAGER_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_SQFT_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SQFT_STORE.setName("store_sqft");
-        COLUMN_STORE_SQFT_STORE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_SQFT_STORE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_STORE_SQFT_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_GROCERY_SQFT_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GROCERY_SQFT_STORE.setName("grocery_sqft");
-        COLUMN_GROCERY_SQFT_STORE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_GROCERY_SQFT_STORE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_GROCERY_SQFT_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_FROZEN_SQFT_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FROZEN_SQFT_STORE.setName("frozen_sqft");
-        COLUMN_FROZEN_SQFT_STORE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FROZEN_SQFT_STORE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_FROZEN_SQFT_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_MEAT_SQFT_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MEAT_SQFT_STORE.setName("meat_sqft");
-        COLUMN_MEAT_SQFT_STORE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_MEAT_SQFT_STORE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_MEAT_SQFT_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_COFFEE_BAR_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COFFEE_BAR_STORE.setName("coffee_bar");
-        COLUMN_COFFEE_BAR_STORE.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_COFFEE_BAR_STORE.setType(SQLSimpleTypes.Sql99.booleanType());
         COLUMN_COFFEE_BAR_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_POSTAL_CODE_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_POSTAL_CODE_STORE.setName("store_postal_code");
-        COLUMN_STORE_POSTAL_CODE_STORE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_POSTAL_CODE_STORE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_POSTAL_CODE_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_NUMBER_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_NUMBER_STORE.setName("store_number");
-        COLUMN_STORE_NUMBER_STORE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_NUMBER_STORE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_STORE_NUMBER_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STREET_ADDRESS_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STREET_ADDRESS_STORE.setName("store_street_address");
-        COLUMN_STREET_ADDRESS_STORE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STREET_ADDRESS_STORE.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_PRODUCT_ID_AGG_C_SPECIAL_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ID_AGG_C_SPECIAL_SALES_FACT_1997.setName("product_id");
-        COLUMN_PRODUCT_ID_AGG_C_SPECIAL_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ID_AGG_C_SPECIAL_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PROMOTION_ID_AGG_C_SPECIAL_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PROMOTION_ID_AGG_C_SPECIAL_SALES_FACT_1997.setName("promotion_id");
-        COLUMN_PROMOTION_ID_AGG_C_SPECIAL_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PROMOTION_ID_AGG_C_SPECIAL_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMER_ID_AGG_C_SPECIAL_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_ID_AGG_C_SPECIAL_SALES_FACT_1997.setName("customer_id");
-        COLUMN_CUSTOMER_ID_AGG_C_SPECIAL_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_ID_AGG_C_SPECIAL_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_ID_AGG_C_SPECIAL_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_ID_AGG_C_SPECIAL_SALES_FACT_1997.setName("store_id");
-        COLUMN_STORE_ID_AGG_C_SPECIAL_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_ID_AGG_C_SPECIAL_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_TIME_MONTH_AGG_C_SPECIAL_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_MONTH_AGG_C_SPECIAL_SALES_FACT_1997.setName("time_month");
-        COLUMN_TIME_MONTH_AGG_C_SPECIAL_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_TIME_MONTH_AGG_C_SPECIAL_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.smallintType());
 
         COLUMN_TIME_QUARTER_AGG_C_SPECIAL_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_QUARTER_AGG_C_SPECIAL_SALES_FACT_1997.setName("time_quarter");
-        COLUMN_TIME_QUARTER_AGG_C_SPECIAL_SALES_FACT_1997.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_TIME_QUARTER_AGG_C_SPECIAL_SALES_FACT_1997.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_TIME_YEAR_AGG_C_SPECIAL_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_YEAR_AGG_C_SPECIAL_SALES_FACT_1997.setName("time_year");
-        COLUMN_TIME_YEAR_AGG_C_SPECIAL_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_TIME_YEAR_AGG_C_SPECIAL_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.smallintType());
 
         COLUMN_STORE_SALES_SUM_AGG_C_SPECIAL_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_SUM_AGG_C_SPECIAL_SALES_FACT_1997.setName("store_sales_sum");
-        COLUMN_STORE_SALES_SUM_AGG_C_SPECIAL_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_SALES_SUM_AGG_C_SPECIAL_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_STORE_COST_SUM_AGG_C_SPECIAL_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_SUM_AGG_C_SPECIAL_SALES_FACT_1997.setName("store_cost_sum");
-        COLUMN_STORE_COST_SUM_AGG_C_SPECIAL_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_COST_SUM_AGG_C_SPECIAL_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_UNIT_SALES_SUM_AGG_C_SPECIAL_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_SUM_AGG_C_SPECIAL_SALES_FACT_1997.setName("unit_sales_sum");
-        COLUMN_UNIT_SALES_SUM_AGG_C_SPECIAL_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_UNIT_SALES_SUM_AGG_C_SPECIAL_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_FACT_COUNT_AGG_C_SPECIAL_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FACT_COUNT_AGG_C_SPECIAL_SALES_FACT_1997.setName("fact_count");
-        COLUMN_FACT_COUNT_AGG_C_SPECIAL_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FACT_COUNT_AGG_C_SPECIAL_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         //unit_sales,customer_count,fact_count
         //DECIMAL(10.4),INTEGER,INTEGER
         COLUMN_MONTH_YEAR_AGG_C_10_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MONTH_YEAR_AGG_C_10_SALES_FACT_1997.setName("month_of_year");
-        COLUMN_MONTH_YEAR_AGG_C_10_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_MONTH_YEAR_AGG_C_10_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.smallintType());
 
         COLUMN_QUARTER_AGG_C_10_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_QUARTER_AGG_C_10_SALES_FACT_1997.setName("quarter");
-        COLUMN_QUARTER_AGG_C_10_SALES_FACT_1997.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_QUARTER_AGG_C_10_SALES_FACT_1997.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_THE_YEAR_AGG_C_10_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_THE_YEAR_AGG_C_10_SALES_FACT_1997.setName("the_year");
-        COLUMN_THE_YEAR_AGG_C_10_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_THE_YEAR_AGG_C_10_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.smallintType());
 
         COLUMN_STORE_SALES_AGG_C_10_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_AGG_C_10_SALES_FACT_1997.setName("store_sales");
-        COLUMN_STORE_SALES_AGG_C_10_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_SALES_AGG_C_10_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_STORE_COST_AGG_C_10_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_AGG_C_10_SALES_FACT_1997.setName("store_cost");
-        COLUMN_STORE_COST_AGG_C_10_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_COST_AGG_C_10_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_UNIT_SALES_AGG_C_10_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_AGG_C_10_SALES_FACT_1997.setName("unit_sales");
-        COLUMN_UNIT_SALES_AGG_C_10_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_UNIT_SALES_AGG_C_10_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_CUSTOMER_COUNT_AGG_C_10_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_COUNT_AGG_C_10_SALES_FACT_1997.setName("customer_count");
-        COLUMN_CUSTOMER_COUNT_AGG_C_10_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_COUNT_AGG_C_10_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_FACT_COUNT_AGG_C_10_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FACT_COUNT_AGG_C_10_SALES_FACT_1997.setName("fact_count");
-        COLUMN_FACT_COUNT_AGG_C_10_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FACT_COUNT_AGG_C_10_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         //store_sales,store_cost,unit_sales,fact_count
         //DECIMAL(10.4),DECIMAL(10.4),DECIMAL(10.4),INTEGER
         COLUMN_PRODUCT_ID_AGG_L_05_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ID_AGG_L_05_SALES_FACT_1997.setName("product_id");
-        COLUMN_PRODUCT_ID_AGG_L_05_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ID_AGG_L_05_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMER_ID_AGG_L_05_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_ID_AGG_L_05_SALES_FACT_1997.setName("customer_id");
-        COLUMN_CUSTOMER_ID_AGG_L_05_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_ID_AGG_L_05_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PROMOTION_ID_AGG_L_05_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PROMOTION_ID_AGG_L_05_SALES_FACT_1997.setName("promotion_id");
-        COLUMN_PROMOTION_ID_AGG_L_05_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PROMOTION_ID_AGG_L_05_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_ID_AGG_L_05_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_ID_AGG_L_05_SALES_FACT_1997.setName("store_id");
-        COLUMN_STORE_ID_AGG_L_05_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_ID_AGG_L_05_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_SALES_AGG_L_05_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_AGG_L_05_SALES_FACT_1997.setName("store_sales");
-        COLUMN_STORE_SALES_AGG_L_05_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_SALES_AGG_L_05_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_STORE_COST_AGG_L_05_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_AGG_L_05_SALES_FACT_1997.setName("store_cost");
-        COLUMN_STORE_COST_AGG_L_05_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_COST_AGG_L_05_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_UNIT_SALES_AGG_L_05_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_AGG_L_05_SALES_FACT_1997.setName("unit_sales");
-        COLUMN_UNIT_SALES_AGG_L_05_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_UNIT_SALES_AGG_L_05_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_FACT_COUNT_AGG_L_05_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FACT_COUNT_AGG_L_05_SALES_FACT_1997.setName("fact_count");
-        COLUMN_FACT_COUNT_AGG_L_05_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FACT_COUNT_AGG_L_05_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCT_ID_AGG_PL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ID_AGG_PL_01_SALES_FACT_1997.setName("product_id");
-        COLUMN_PRODUCT_ID_AGG_PL_01_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ID_AGG_PL_01_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_TIME_ID_AGG_PL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_AGG_PL_01_SALES_FACT_1997.setName("time_id");
-        COLUMN_TIME_ID_AGG_PL_01_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_ID_AGG_PL_01_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMER_ID_AGG_PL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_ID_AGG_PL_01_SALES_FACT_1997.setName("customer_id");
-        COLUMN_CUSTOMER_ID_AGG_PL_01_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_ID_AGG_PL_01_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_SALES_SUM_AGG_PL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_SUM_AGG_PL_01_SALES_FACT_1997.setName("store_sales_sum");
-        COLUMN_STORE_SALES_SUM_AGG_PL_01_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_SALES_SUM_AGG_PL_01_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_STORE_COST_SUM_AGG_PL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_SUM_AGG_PL_01_SALES_FACT_1997.setName("store_cost_sum");
-        COLUMN_STORE_COST_SUM_AGG_PL_01_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_COST_SUM_AGG_PL_01_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_UNIT_SALES_SUM_AGG_PL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_SUM_AGG_PL_01_SALES_FACT_1997.setName("unit_sales_sum");
-        COLUMN_UNIT_SALES_SUM_AGG_PL_01_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_UNIT_SALES_SUM_AGG_PL_01_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_FACT_COUNT_AGG_PL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FACT_COUNT_AGG_PL_01_SALES_FACT_1997.setName("fact_count");
-        COLUMN_FACT_COUNT_AGG_PL_01_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FACT_COUNT_AGG_PL_01_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_TIME_ID_AGG_L_03_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_AGG_L_03_SALES_FACT_1997.setName("time_id");
-        COLUMN_TIME_ID_AGG_L_03_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_ID_AGG_L_03_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMER_ID_AGG_L_03_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_ID_AGG_L_03_SALES_FACT_1997.setName("customer_id");
-        COLUMN_CUSTOMER_ID_AGG_L_03_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_ID_AGG_L_03_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_SALES_AGG_L_03_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_AGG_L_03_SALES_FACT_1997.setName("store_sales");
-        COLUMN_STORE_SALES_AGG_L_03_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_SALES_AGG_L_03_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_STORE_COST_AGG_L_03_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_AGG_L_03_SALES_FACT_1997.setName("store_cost");
-        COLUMN_STORE_COST_AGG_L_03_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_COST_AGG_L_03_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_UNIT_SALES_AGG_L_03_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_AGG_L_03_SALES_FACT_1997.setName("unit_sales");
-        COLUMN_UNIT_SALES_AGG_L_03_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_UNIT_SALES_AGG_L_03_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_FACT_COUNT_AGG_L_03_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FACT_COUNT_AGG_L_03_SALES_FACT_1997.setName("fact_count");
-        COLUMN_FACT_COUNT_AGG_L_03_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FACT_COUNT_AGG_L_03_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         //fact_count
         //INTEGER
         COLUMN_GENDER_AGG_G_MS_PCAT_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GENDER_AGG_G_MS_PCAT_SALES_FACT_1997.setName("gender");
-        COLUMN_GENDER_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_GENDER_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_MARITAL_STATUS_AGG_G_MS_PCAT_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MARITAL_STATUS_AGG_G_MS_PCAT_SALES_FACT_1997.setName("marital_status");
-        COLUMN_MARITAL_STATUS_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_MARITAL_STATUS_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_PRODUCT_FAMILY_AGG_G_MS_PCAT_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_FAMILY_AGG_G_MS_PCAT_SALES_FACT_1997.setName("product_family");
-        COLUMN_PRODUCT_FAMILY_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_PRODUCT_FAMILY_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_PRODUCT_FAMILY_AGG_G_MS_PCAT_SALES_FACT_1997.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_PRODUCT_DEPARTMENT_AGG_G_MS_PCAT_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_DEPARTMENT_AGG_G_MS_PCAT_SALES_FACT_1997.setName("product_department");
-        COLUMN_PRODUCT_DEPARTMENT_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_PRODUCT_DEPARTMENT_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_PRODUCT_DEPARTMENT_AGG_G_MS_PCAT_SALES_FACT_1997.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_PRODUCT_CATEGORY_AGG_G_MS_PCAT_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_CATEGORY_AGG_G_MS_PCAT_SALES_FACT_1997.setName("product_category");
-        COLUMN_PRODUCT_CATEGORY_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_PRODUCT_CATEGORY_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_PRODUCT_CATEGORY_AGG_G_MS_PCAT_SALES_FACT_1997.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_MONTH_YEAR_AGG_G_MS_PCAT_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MONTH_YEAR_AGG_G_MS_PCAT_SALES_FACT_1997.setName("month_of_year");
-        COLUMN_MONTH_YEAR_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_MONTH_YEAR_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.smallintType());
 
         COLUMN_QUARTER_AGG_G_MS_PCAT_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_QUARTER_AGG_G_MS_PCAT_SALES_FACT_1997.setName("quarter");
-        COLUMN_QUARTER_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_QUARTER_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_THE_YEAR_AGG_G_MS_PCAT_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_THE_YEAR_AGG_G_MS_PCAT_SALES_FACT_1997.setName("the_year");
-        COLUMN_THE_YEAR_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_THE_YEAR_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.smallintType());
 
         COLUMN_STORE_SALES_AGG_G_MS_PCAT_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_AGG_G_MS_PCAT_SALES_FACT_1997.setName("store_sales");
-        COLUMN_STORE_SALES_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_SALES_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_STORE_COST_AGG_G_MS_PCAT_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_AGG_G_MS_PCAT_SALES_FACT_1997.setName("store_cost");
-        COLUMN_STORE_COST_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_COST_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_UNIT_SALES_AGG_G_MS_PCAT_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_AGG_G_MS_PCAT_SALES_FACT_1997.setName("unit_sales");
-        COLUMN_UNIT_SALES_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_UNIT_SALES_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_CUSTOMER_COUNT_AGG_G_MS_PCAT_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_COUNT_AGG_G_MS_PCAT_SALES_FACT_1997.setName("customer_count");
-        COLUMN_CUSTOMER_COUNT_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_COUNT_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_FACT_COUNT_AGG_G_MS_PCAT_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FACT_COUNT_AGG_G_MS_PCAT_SALES_FACT_1997.setName("fact_count");
-        COLUMN_FACT_COUNT_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FACT_COUNT_AGG_G_MS_PCAT_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         //store_sales,store_cost,unit_sales,fact_count
         //DECIMAL(10.4),DECIMAL(10.4),DECIMAL(10.4),INTEGER
         COLUMN_PRODUCT_ID_AGG_C_14_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ID_AGG_C_14_SALES_FACT_1997.setName("product_id");
-        COLUMN_PRODUCT_ID_AGG_C_14_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ID_AGG_C_14_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMER_ID_AGG_C_14_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_ID_AGG_C_14_SALES_FACT_1997.setName("customer_id");
-        COLUMN_CUSTOMER_ID_AGG_C_14_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_ID_AGG_C_14_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_ID_AGG_C_14_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_ID_AGG_C_14_SALES_FACT_1997.setName("store_id");
-        COLUMN_STORE_ID_AGG_C_14_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_ID_AGG_C_14_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PROMOTION_ID_AGG_C_14_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PROMOTION_ID_AGG_C_14_SALES_FACT_1997.setName("promotion_id");
-        COLUMN_PROMOTION_ID_AGG_C_14_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PROMOTION_ID_AGG_C_14_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_MONTH_YEAR_AGG_C_14_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MONTH_YEAR_AGG_C_14_SALES_FACT_1997.setName("month_of_year");
-        COLUMN_MONTH_YEAR_AGG_C_14_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_MONTH_YEAR_AGG_C_14_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.smallintType());
 
         COLUMN_QUARTER_AGG_C_14_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_QUARTER_AGG_C_14_SALES_FACT_1997.setName("quarter");
-        COLUMN_QUARTER_AGG_C_14_SALES_FACT_1997.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_QUARTER_AGG_C_14_SALES_FACT_1997.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_THE_YEAR_AGG_C_14_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_THE_YEAR_AGG_C_14_SALES_FACT_1997.setName("the_year");
-        COLUMN_THE_YEAR_AGG_C_14_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_THE_YEAR_AGG_C_14_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.smallintType());
 
         COLUMN_STORE_SALES_AGG_C_14_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_AGG_C_14_SALES_FACT_1997.setName("store_sales");
-        COLUMN_STORE_SALES_AGG_C_14_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_SALES_AGG_C_14_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_STORE_COST_AGG_C_14_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_AGG_C_14_SALES_FACT_1997.setName("store_cost");
-        COLUMN_STORE_COST_AGG_C_14_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_STORE_COST_AGG_C_14_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_UNIT_SALES_AGG_C_14_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_AGG_C_14_SALES_FACT_1997.setName("unit_sales");
-        COLUMN_UNIT_SALES_AGG_C_14_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_UNIT_SALES_AGG_C_14_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_FACT_COUNT_AGG_C_14_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FACT_COUNT_AGG_C_14_SALES_FACT_1997.setName("fact_count");
-        COLUMN_FACT_COUNT_AGG_C_14_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FACT_COUNT_AGG_C_14_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         //quarter,fiscal_period
         //VARCHAR(30),VARCHAR(30)
         COLUMN_TIME_ID_TIME_BY_DAY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_TIME_BY_DAY.setName("time_id");
-        COLUMN_TIME_ID_TIME_BY_DAY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_ID_TIME_BY_DAY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_THE_DATE_TIME_BY_DAY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_THE_DATE_TIME_BY_DAY.setName("the_date");
-        COLUMN_THE_DATE_TIME_BY_DAY.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_THE_DATE_TIME_BY_DAY.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_THE_DATE_TIME_BY_DAY.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_THE_DAY_TIME_BY_DAY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_THE_DAY_TIME_BY_DAY.setName("the_day");
-        COLUMN_THE_DAY_TIME_BY_DAY.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_THE_DAY_TIME_BY_DAY.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_THE_DAY_TIME_BY_DAY.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_THE_MONTH_TIME_BY_DAY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_THE_MONTH_TIME_BY_DAY.setName("the_month");
-        COLUMN_THE_MONTH_TIME_BY_DAY.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_THE_MONTH_TIME_BY_DAY.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_THE_MONTH_TIME_BY_DAY.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_THE_YEAR_TIME_BY_DAY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_THE_YEAR_TIME_BY_DAY.setName("the_year");
-        COLUMN_THE_YEAR_TIME_BY_DAY.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_THE_YEAR_TIME_BY_DAY.setType(SQLSimpleTypes.Sql99.smallintType());
         COLUMN_THE_YEAR_TIME_BY_DAY.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_DAY_OF_MONTH_TIME_BY_DAY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DAY_OF_MONTH_TIME_BY_DAY.setName("day_of_month");
-        COLUMN_DAY_OF_MONTH_TIME_BY_DAY.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_DAY_OF_MONTH_TIME_BY_DAY.setType(SQLSimpleTypes.Sql99.smallintType());
         COLUMN_DAY_OF_MONTH_TIME_BY_DAY.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WEEK_OF_YEAR_TIME_BY_DAY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WEEK_OF_YEAR_TIME_BY_DAY.setName("week_of_year");
-        COLUMN_WEEK_OF_YEAR_TIME_BY_DAY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_WEEK_OF_YEAR_TIME_BY_DAY.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_WEEK_OF_YEAR_TIME_BY_DAY.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_MONTH_OF_YEAR_TIME_BY_DAY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MONTH_OF_YEAR_TIME_BY_DAY.setName("month_of_year");
-        COLUMN_MONTH_OF_YEAR_TIME_BY_DAY.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_MONTH_OF_YEAR_TIME_BY_DAY.setType(SQLSimpleTypes.Sql99.smallintType());
         COLUMN_MONTH_OF_YEAR_TIME_BY_DAY.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_QUARTER_TIME_BY_DAY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_QUARTER_TIME_BY_DAY.setName("quarter");
-        COLUMN_QUARTER_TIME_BY_DAY.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_QUARTER_TIME_BY_DAY.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_QUARTER_TIME_BY_DAY.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_FISCAL_PERIOD_TIME_BY_DAY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FISCAL_PERIOD_TIME_BY_DAY.setName("fiscal_period");
-        COLUMN_FISCAL_PERIOD_TIME_BY_DAY.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_FISCAL_PERIOD_TIME_BY_DAY.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_FISCAL_PERIOD_TIME_BY_DAY.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         //region_id,store_name,store_number,store_street_address,store_city,store_state,store_postal_code,store_country,store_manager,store_phone,store_fax,first_opened_date,last_remodel_date,store_sqft,grocery_sqft,frozen_sqft,meat_sqft,coffee_bar,video_store,salad_bar,prepared_food,florist
@@ -2253,71 +2255,71 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         COLUMN_STORE_ID_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_ID_STORE_RAGGED.setName("store_id");
-        COLUMN_STORE_ID_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_ID_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_TYPE_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_TYPE_STORE_RAGGED.setName("store_type");
-        COLUMN_STORE_TYPE_STORE_RAGGED.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_TYPE_STORE_RAGGED.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_TYPE_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_NAME_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_NAME_STORE_RAGGED.setName("store_name");
-        COLUMN_STORE_NAME_STORE_RAGGED.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_NAME_STORE_RAGGED.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_NAME_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STREET_ADDRESS_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STREET_ADDRESS_STORE_RAGGED.setName("store_street_address");
-        COLUMN_STREET_ADDRESS_STORE_RAGGED.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STREET_ADDRESS_STORE_RAGGED.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STREET_ADDRESS_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_STATE_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_STATE_STORE_RAGGED.setName("store_state");
-        COLUMN_STORE_STATE_STORE_RAGGED.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_STATE_STORE_RAGGED.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_STATE_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_COUNTRY_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COUNTRY_STORE_RAGGED.setName("store_country");
-        COLUMN_STORE_COUNTRY_STORE_RAGGED.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_COUNTRY_STORE_RAGGED.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_COUNTRY_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_MANAGER_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_MANAGER_STORE_RAGGED.setName("store_manager");
-        COLUMN_STORE_MANAGER_STORE_RAGGED.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_MANAGER_STORE_RAGGED.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_MANAGER_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_CITY_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_CITY_STORE_RAGGED.setName("store_city");
-        COLUMN_STORE_CITY_STORE_RAGGED.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_CITY_STORE_RAGGED.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_CITY_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_SQFT_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SQFT_STORE_RAGGED.setName("store_sqft");
-        COLUMN_STORE_SQFT_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_SQFT_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_STORE_SQFT_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_GROCERY_SQFT_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GROCERY_SQFT_STORE_RAGGED.setName("grocery_sqft");
-        COLUMN_GROCERY_SQFT_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_GROCERY_SQFT_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_GROCERY_SQFT_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_FROZEN_SQFT_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FROZEN_SQFT_STORE_RAGGED.setName("frozen_sqft");
-        COLUMN_FROZEN_SQFT_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FROZEN_SQFT_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_FROZEN_SQFT_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_MEAT_SQFT_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MEAT_SQFT_STORE_RAGGED.setName("meat_sqft");
-        COLUMN_MEAT_SQFT_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_MEAT_SQFT_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_MEAT_SQFT_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_COFFEE_BAR_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COFFEE_BAR_STORE_RAGGED.setName("coffee_bar");
-        COLUMN_COFFEE_BAR_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_COFFEE_BAR_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.booleanType());
         COLUMN_COFFEE_BAR_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_REGION_ID_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_REGION_ID_STORE_RAGGED.setName("region_id");
-        COLUMN_REGION_ID_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_REGION_ID_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_REGION_ID_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         MEASURE_PROMOTION_SALES_COL_SQL_STATEMENT1 = SourceFactory.eINSTANCE.createSqlStatement();
@@ -2340,7 +2342,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         MEASURE_PROMOTION_SALES_COL = org.eclipse.daanse.rolap.mapping.model.database.relational.RelationalFactory.eINSTANCE.createExpressionColumn();
         MEASURE_PROMOTION_SALES_COL.getSqls().addAll(List.of(MEASURE_PROMOTION_SALES_COL_SQL_STATEMENT1, MEASURE_PROMOTION_SALES_COL_SQL_STATEMENT2,
                 MEASURE_PROMOTION_SALES_COL_SQL_STATEMENT3, MEASURE_PROMOTION_SALES_COL_SQL_STATEMENT4));
-        MEASURE_PROMOTION_SALES_COL.setType(SqlSimpleTypes.decimalType(18, 4));
+        MEASURE_PROMOTION_SALES_COL.setType(SQLSimpleTypes.decimalType(18, 4));
 
         MEASURE_WAREHOUSE_PROFIT_COL_SQL_STATEMENT1 = SourceFactory.eINSTANCE.createSqlStatement();
         MEASURE_WAREHOUSE_PROFIT_COL_SQL_STATEMENT1.getDialects().addAll(List.of("mysql", "mariadb", "infobright"));
@@ -2353,7 +2355,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         MEASURE_WAREHOUSE_PROFIT_COL = org.eclipse.daanse.rolap.mapping.model.database.relational.RelationalFactory.eINSTANCE.createExpressionColumn();
         MEASURE_WAREHOUSE_PROFIT_COL.getSqls().addAll(List.of(MEASURE_WAREHOUSE_PROFIT_COL_SQL_STATEMENT1, MEASURE_WAREHOUSE_PROFIT_COL_SQL_STATEMENT2));
-        MEASURE_WAREHOUSE_PROFIT_COL.setType(SqlSimpleTypes.decimalType(18, 4));
+        MEASURE_WAREHOUSE_PROFIT_COL.setType(SQLSimpleTypes.decimalType(18, 4));
 
         // Initialize tables
         //product_id,time_id,customer_id,promotion_id,store_id,store_sales,store_cost,unit_sales
@@ -3200,7 +3202,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         SQL_EXPRESSION_COLUMN_NAME = org.eclipse.daanse.rolap.mapping.model.database.relational.RelationalFactory.eINSTANCE.createExpressionColumn();
         SQL_EXPRESSION_COLUMN_NAME.getSqls().addAll(List.of(NAME_COL_SQL_STATEMENT1, NAME_COL_SQL_STATEMENT2, NAME_COL_SQL_STATEMENT3, NAME_COL_SQL_STATEMENT4,
                 NAME_COL_SQL_STATEMENT5, NAME_COL_SQL_STATEMENT6, NAME_COL_SQL_STATEMENT7));
-        SQL_EXPRESSION_COLUMN_NAME.setType(SqlSimpleTypes.Sql99.varcharType());
+        SQL_EXPRESSION_COLUMN_NAME.setType(SQLSimpleTypes.Sql99.varcharType());
 
         NAME_ORDER_COL_SQL_STATEMENT1 = SourceFactory.eINSTANCE.createSqlStatement();
         NAME_ORDER_COL_SQL_STATEMENT1.getDialects().addAll(List.of("oracle", "h2", "hsqldb", "postgres", "luciddb"));
@@ -3229,7 +3231,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         SQL_EXPRESSION_COLUMN_NAME_ORDER = org.eclipse.daanse.rolap.mapping.model.database.relational.RelationalFactory.eINSTANCE.createExpressionColumn();
         SQL_EXPRESSION_COLUMN_NAME_ORDER.getSqls().addAll(List.of(NAME_ORDER_COL_SQL_STATEMENT1, NAME_ORDER_COL_SQL_STATEMENT2, NAME_ORDER_COL_SQL_STATEMENT3, NAME_ORDER_COL_SQL_STATEMENT4,
                 NAME_ORDER_COL_SQL_STATEMENT5, NAME_ORDER_COL_SQL_STATEMENT6));
-        SQL_EXPRESSION_COLUMN_NAME_ORDER.setType(SqlSimpleTypes.Sql99.varcharType());
+        SQL_EXPRESSION_COLUMN_NAME_ORDER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         ORDERED_SQL_EXPRESSION_COLUMN_NAME_ORDER = RelationalFactory.eINSTANCE.createOrderedColumn();
         ORDERED_SQL_EXPRESSION_COLUMN_NAME_ORDER.setColumn(SQL_EXPRESSION_COLUMN_NAME_ORDER);
@@ -4291,86 +4293,86 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
                         TABLE_TIME_BY_DAY, TABLE_STORE_RAGGED ));
         COLUMN_PRODUCT_ID_SALES_FACT_DEC_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ID_SALES_FACT_DEC_1998.setName("product_id");
-        COLUMN_PRODUCT_ID_SALES_FACT_DEC_1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ID_SALES_FACT_DEC_1998.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_TIME_ID_SALES_FACT_DEC_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_SALES_FACT_DEC_1998.setName("time_id");
-        COLUMN_TIME_ID_SALES_FACT_DEC_1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_ID_SALES_FACT_DEC_1998.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMER_ID_SALES_FACT_DEC_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_ID_SALES_FACT_DEC_1998.setName("customer_id");
-        COLUMN_CUSTOMER_ID_SALES_FACT_DEC_1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_ID_SALES_FACT_DEC_1998.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PROMOTION_ID_SALES_FACT_DEC_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PROMOTION_ID_SALES_FACT_DEC_1998.setName("promotion_id");
-        COLUMN_PROMOTION_ID_SALES_FACT_DEC_1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PROMOTION_ID_SALES_FACT_DEC_1998.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_ID_SALES_FACT_DEC_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_ID_SALES_FACT_DEC_1998.setName("store_id");
-        COLUMN_STORE_ID_SALES_FACT_DEC_1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_ID_SALES_FACT_DEC_1998.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_SALES_SALES_FACT_DEC_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_SALES_FACT_DEC_1998.setName("store_sales");
-        COLUMN_STORE_SALES_SALES_FACT_DEC_1998.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_STORE_SALES_SALES_FACT_DEC_1998.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_STORE_COST_SALES_FACT_DEC_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_SALES_FACT_DEC_1998.setName("store_cost");
-        COLUMN_STORE_COST_SALES_FACT_DEC_1998.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_STORE_COST_SALES_FACT_DEC_1998.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_UNIT_SALES_SALES_FACT_DEC_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_SALES_FACT_DEC_1998.setName("unit_sales");
-        COLUMN_UNIT_SALES_SALES_FACT_DEC_1998.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_UNIT_SALES_SALES_FACT_DEC_1998.setType(SQLSimpleTypes.decimalType(10, 4));
 
         TABLE_SALES_FACT_DEC_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         TABLE_SALES_FACT_DEC_1998.setName("sales_fact_dec_1998");
         TABLE_SALES_FACT_DEC_1998.getFeature().addAll(List.of(COLUMN_PRODUCT_ID_SALES_FACT_DEC_1998, COLUMN_TIME_ID_SALES_FACT_DEC_1998, COLUMN_CUSTOMER_ID_SALES_FACT_DEC_1998, COLUMN_PROMOTION_ID_SALES_FACT_DEC_1998, COLUMN_STORE_ID_SALES_FACT_DEC_1998, COLUMN_STORE_SALES_SALES_FACT_DEC_1998, COLUMN_STORE_COST_SALES_FACT_DEC_1998, COLUMN_UNIT_SALES_SALES_FACT_DEC_1998));
         COLUMN_PRODUCT_ID_INVENTORY_FACT_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ID_INVENTORY_FACT_1998.setName("product_id");
-        COLUMN_PRODUCT_ID_INVENTORY_FACT_1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ID_INVENTORY_FACT_1998.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_TIME_ID_INVENTORY_FACT_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_INVENTORY_FACT_1998.setName("time_id");
-        COLUMN_TIME_ID_INVENTORY_FACT_1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_ID_INVENTORY_FACT_1998.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_TIME_ID_INVENTORY_FACT_1998.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WAREHOUSE_ID_INVENTORY_FACT_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_ID_INVENTORY_FACT_1998.setName("warehouse_id");
-        COLUMN_WAREHOUSE_ID_INVENTORY_FACT_1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_WAREHOUSE_ID_INVENTORY_FACT_1998.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_WAREHOUSE_ID_INVENTORY_FACT_1998.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_ID_INVENTORY_FACT_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_ID_INVENTORY_FACT_1998.setName("store_id");
-        COLUMN_STORE_ID_INVENTORY_FACT_1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_ID_INVENTORY_FACT_1998.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_STORE_ID_INVENTORY_FACT_1998.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_UNITS_ORDERED_INVENTORY_FACT_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNITS_ORDERED_INVENTORY_FACT_1998.setName("units_ordered");
-        COLUMN_UNITS_ORDERED_INVENTORY_FACT_1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_UNITS_ORDERED_INVENTORY_FACT_1998.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_UNITS_ORDERED_INVENTORY_FACT_1998.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_UNITS_SHIPPED_INVENTORY_FACT_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNITS_SHIPPED_INVENTORY_FACT_1998.setName("units_shipped");
-        COLUMN_UNITS_SHIPPED_INVENTORY_FACT_1998.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_UNITS_SHIPPED_INVENTORY_FACT_1998.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_UNITS_SHIPPED_INVENTORY_FACT_1998.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WAREHOUSE_SALES_INVENTORY_FACT_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_SALES_INVENTORY_FACT_1998.setName("warehouse_sales");
-        COLUMN_WAREHOUSE_SALES_INVENTORY_FACT_1998.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_WAREHOUSE_SALES_INVENTORY_FACT_1998.setType(SQLSimpleTypes.decimalType(10, 4));
         COLUMN_WAREHOUSE_SALES_INVENTORY_FACT_1998.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WAREHOUSE_COST_INVENTORY_FACT_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_COST_INVENTORY_FACT_1998.setName("warehouse_cost");
-        COLUMN_WAREHOUSE_COST_INVENTORY_FACT_1998.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_WAREHOUSE_COST_INVENTORY_FACT_1998.setType(SQLSimpleTypes.decimalType(10, 4));
         COLUMN_WAREHOUSE_COST_INVENTORY_FACT_1998.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SUPPLY_TIME_INVENTORY_FACT_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SUPPLY_TIME_INVENTORY_FACT_1998.setName("supply_time");
-        COLUMN_SUPPLY_TIME_INVENTORY_FACT_1998.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_SUPPLY_TIME_INVENTORY_FACT_1998.setType(SQLSimpleTypes.Sql99.smallintType());
         COLUMN_SUPPLY_TIME_INVENTORY_FACT_1998.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_INVOICE_INVENTORY_FACT_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_INVOICE_INVENTORY_FACT_1998.setName("store_invoice");
-        COLUMN_STORE_INVOICE_INVENTORY_FACT_1998.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_STORE_INVOICE_INVENTORY_FACT_1998.setType(SQLSimpleTypes.decimalType(10, 4));
         COLUMN_STORE_INVOICE_INVENTORY_FACT_1998.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         TABLE_INVENTORY_FACT_1998 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
@@ -4378,176 +4380,176 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         TABLE_INVENTORY_FACT_1998.getFeature().addAll(List.of(COLUMN_PRODUCT_ID_INVENTORY_FACT_1998, COLUMN_TIME_ID_INVENTORY_FACT_1998, COLUMN_WAREHOUSE_ID_INVENTORY_FACT_1998, COLUMN_STORE_ID_INVENTORY_FACT_1998, COLUMN_UNITS_ORDERED_INVENTORY_FACT_1998, COLUMN_UNITS_SHIPPED_INVENTORY_FACT_1998, COLUMN_WAREHOUSE_SALES_INVENTORY_FACT_1998, COLUMN_WAREHOUSE_COST_INVENTORY_FACT_1998, COLUMN_SUPPLY_TIME_INVENTORY_FACT_1998, COLUMN_STORE_INVOICE_INVENTORY_FACT_1998));
         COLUMN_PRODUCT_ID_AGG_LL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ID_AGG_LL_01_SALES_FACT_1997.setName("product_id");
-        COLUMN_PRODUCT_ID_AGG_LL_01_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ID_AGG_LL_01_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_TIME_ID_AGG_LL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_AGG_LL_01_SALES_FACT_1997.setName("time_id");
-        COLUMN_TIME_ID_AGG_LL_01_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_ID_AGG_LL_01_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMER_ID_AGG_LL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_ID_AGG_LL_01_SALES_FACT_1997.setName("customer_id");
-        COLUMN_CUSTOMER_ID_AGG_LL_01_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_ID_AGG_LL_01_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_SALES_AGG_LL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_AGG_LL_01_SALES_FACT_1997.setName("store_sales");
-        COLUMN_STORE_SALES_AGG_LL_01_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_STORE_SALES_AGG_LL_01_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_STORE_COST_AGG_LL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_AGG_LL_01_SALES_FACT_1997.setName("store_cost");
-        COLUMN_STORE_COST_AGG_LL_01_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_STORE_COST_AGG_LL_01_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_UNIT_SALES_AGG_LL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_AGG_LL_01_SALES_FACT_1997.setName("unit_sales");
-        COLUMN_UNIT_SALES_AGG_LL_01_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_UNIT_SALES_AGG_LL_01_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_FACT_COUNT_AGG_LL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FACT_COUNT_AGG_LL_01_SALES_FACT_1997.setName("fact_count");
-        COLUMN_FACT_COUNT_AGG_LL_01_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FACT_COUNT_AGG_LL_01_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         TABLE_AGG_LL_01_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         TABLE_AGG_LL_01_SALES_FACT_1997.setName("agg_ll_01_sales_fact_1997");
         TABLE_AGG_LL_01_SALES_FACT_1997.getFeature().addAll(List.of(COLUMN_PRODUCT_ID_AGG_LL_01_SALES_FACT_1997, COLUMN_TIME_ID_AGG_LL_01_SALES_FACT_1997, COLUMN_CUSTOMER_ID_AGG_LL_01_SALES_FACT_1997, COLUMN_STORE_SALES_AGG_LL_01_SALES_FACT_1997, COLUMN_STORE_COST_AGG_LL_01_SALES_FACT_1997, COLUMN_UNIT_SALES_AGG_LL_01_SALES_FACT_1997, COLUMN_FACT_COUNT_AGG_LL_01_SALES_FACT_1997));
         COLUMN_TIME_ID_AGG_L_04_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_AGG_L_04_SALES_FACT_1997.setName("time_id");
-        COLUMN_TIME_ID_AGG_L_04_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_ID_AGG_L_04_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STORE_SALES_AGG_L_04_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_AGG_L_04_SALES_FACT_1997.setName("store_sales");
-        COLUMN_STORE_SALES_AGG_L_04_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_STORE_SALES_AGG_L_04_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_STORE_COST_AGG_L_04_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_AGG_L_04_SALES_FACT_1997.setName("store_cost");
-        COLUMN_STORE_COST_AGG_L_04_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_STORE_COST_AGG_L_04_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_UNIT_SALES_AGG_L_04_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_AGG_L_04_SALES_FACT_1997.setName("unit_sales");
-        COLUMN_UNIT_SALES_AGG_L_04_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_UNIT_SALES_AGG_L_04_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_CUSTOMER_COUNT_AGG_L_04_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_COUNT_AGG_L_04_SALES_FACT_1997.setName("customer_count");
-        COLUMN_CUSTOMER_COUNT_AGG_L_04_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_COUNT_AGG_L_04_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_FACT_COUNT_AGG_L_04_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FACT_COUNT_AGG_L_04_SALES_FACT_1997.setName("fact_count");
-        COLUMN_FACT_COUNT_AGG_L_04_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FACT_COUNT_AGG_L_04_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         TABLE_AGG_L_04_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         TABLE_AGG_L_04_SALES_FACT_1997.setName("agg_l_04_sales_fact_1997");
         TABLE_AGG_L_04_SALES_FACT_1997.getFeature().addAll(List.of(COLUMN_TIME_ID_AGG_L_04_SALES_FACT_1997, COLUMN_STORE_SALES_AGG_L_04_SALES_FACT_1997, COLUMN_STORE_COST_AGG_L_04_SALES_FACT_1997, COLUMN_UNIT_SALES_AGG_L_04_SALES_FACT_1997, COLUMN_CUSTOMER_COUNT_AGG_L_04_SALES_FACT_1997, COLUMN_FACT_COUNT_AGG_L_04_SALES_FACT_1997));
         COLUMN_PRODUCT_ID_AGG_LC_100_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCT_ID_AGG_LC_100_SALES_FACT_1997.setName("product_id");
-        COLUMN_PRODUCT_ID_AGG_LC_100_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PRODUCT_ID_AGG_LC_100_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMER_ID_AGG_LC_100_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMER_ID_AGG_LC_100_SALES_FACT_1997.setName("customer_id");
-        COLUMN_CUSTOMER_ID_AGG_LC_100_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMER_ID_AGG_LC_100_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_QUARTER_AGG_LC_100_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_QUARTER_AGG_LC_100_SALES_FACT_1997.setName("quarter");
-        COLUMN_QUARTER_AGG_LC_100_SALES_FACT_1997.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_QUARTER_AGG_LC_100_SALES_FACT_1997.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_THE_YEAR_AGG_LC_100_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_THE_YEAR_AGG_LC_100_SALES_FACT_1997.setName("the_year");
-        COLUMN_THE_YEAR_AGG_LC_100_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_THE_YEAR_AGG_LC_100_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.smallintType());
 
         COLUMN_STORE_SALES_AGG_LC_100_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_AGG_LC_100_SALES_FACT_1997.setName("store_sales");
-        COLUMN_STORE_SALES_AGG_LC_100_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_STORE_SALES_AGG_LC_100_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_STORE_COST_AGG_LC_100_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_AGG_LC_100_SALES_FACT_1997.setName("store_cost");
-        COLUMN_STORE_COST_AGG_LC_100_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_STORE_COST_AGG_LC_100_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_UNIT_SALES_AGG_LC_100_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_AGG_LC_100_SALES_FACT_1997.setName("unit_sales");
-        COLUMN_UNIT_SALES_AGG_LC_100_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_UNIT_SALES_AGG_LC_100_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_FACT_COUNT_AGG_LC_100_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FACT_COUNT_AGG_LC_100_SALES_FACT_1997.setName("fact_count");
-        COLUMN_FACT_COUNT_AGG_LC_100_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FACT_COUNT_AGG_LC_100_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         TABLE_AGG_LC_100_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         TABLE_AGG_LC_100_SALES_FACT_1997.setName("agg_lc_100_sales_fact_1997");
         TABLE_AGG_LC_100_SALES_FACT_1997.getFeature().addAll(List.of(COLUMN_PRODUCT_ID_AGG_LC_100_SALES_FACT_1997, COLUMN_CUSTOMER_ID_AGG_LC_100_SALES_FACT_1997, COLUMN_QUARTER_AGG_LC_100_SALES_FACT_1997, COLUMN_THE_YEAR_AGG_LC_100_SALES_FACT_1997, COLUMN_STORE_SALES_AGG_LC_100_SALES_FACT_1997, COLUMN_STORE_COST_AGG_LC_100_SALES_FACT_1997, COLUMN_UNIT_SALES_AGG_LC_100_SALES_FACT_1997, COLUMN_FACT_COUNT_AGG_LC_100_SALES_FACT_1997));
         COLUMN_TIME_ID_AGG_LC_06_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_AGG_LC_06_SALES_FACT_1997.setName("time_id");
-        COLUMN_TIME_ID_AGG_LC_06_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_ID_AGG_LC_06_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CITY_AGG_LC_06_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CITY_AGG_LC_06_SALES_FACT_1997.setName("city");
-        COLUMN_CITY_AGG_LC_06_SALES_FACT_1997.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_CITY_AGG_LC_06_SALES_FACT_1997.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_STATE_PROVINCE_AGG_LC_06_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STATE_PROVINCE_AGG_LC_06_SALES_FACT_1997.setName("state_province");
-        COLUMN_STATE_PROVINCE_AGG_LC_06_SALES_FACT_1997.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STATE_PROVINCE_AGG_LC_06_SALES_FACT_1997.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_COUNTRY_AGG_LC_06_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COUNTRY_AGG_LC_06_SALES_FACT_1997.setName("country");
-        COLUMN_COUNTRY_AGG_LC_06_SALES_FACT_1997.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_COUNTRY_AGG_LC_06_SALES_FACT_1997.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_STORE_SALES_AGG_LC_06_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_SALES_AGG_LC_06_SALES_FACT_1997.setName("store_sales");
-        COLUMN_STORE_SALES_AGG_LC_06_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_STORE_SALES_AGG_LC_06_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_STORE_COST_AGG_LC_06_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_COST_AGG_LC_06_SALES_FACT_1997.setName("store_cost");
-        COLUMN_STORE_COST_AGG_LC_06_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_STORE_COST_AGG_LC_06_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_UNIT_SALES_AGG_LC_06_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UNIT_SALES_AGG_LC_06_SALES_FACT_1997.setName("unit_sales");
-        COLUMN_UNIT_SALES_AGG_LC_06_SALES_FACT_1997.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_UNIT_SALES_AGG_LC_06_SALES_FACT_1997.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_FACT_COUNT_AGG_LC_06_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FACT_COUNT_AGG_LC_06_SALES_FACT_1997.setName("fact_count");
-        COLUMN_FACT_COUNT_AGG_LC_06_SALES_FACT_1997.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_FACT_COUNT_AGG_LC_06_SALES_FACT_1997.setType(SQLSimpleTypes.Sql99.integerType());
 
         TABLE_AGG_LC_06_SALES_FACT_1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         TABLE_AGG_LC_06_SALES_FACT_1997.setName("agg_lc_06_sales_fact_1997");
         TABLE_AGG_LC_06_SALES_FACT_1997.getFeature().addAll(List.of(COLUMN_TIME_ID_AGG_LC_06_SALES_FACT_1997, COLUMN_CITY_AGG_LC_06_SALES_FACT_1997, COLUMN_STATE_PROVINCE_AGG_LC_06_SALES_FACT_1997, COLUMN_COUNTRY_AGG_LC_06_SALES_FACT_1997, COLUMN_STORE_SALES_AGG_LC_06_SALES_FACT_1997, COLUMN_STORE_COST_AGG_LC_06_SALES_FACT_1997, COLUMN_UNIT_SALES_AGG_LC_06_SALES_FACT_1997, COLUMN_FACT_COUNT_AGG_LC_06_SALES_FACT_1997));
         COLUMN_CURRENCY_ID_CURRENCY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CURRENCY_ID_CURRENCY.setName("currency_id");
-        COLUMN_CURRENCY_ID_CURRENCY.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CURRENCY_ID_CURRENCY.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DATE_CURRENCY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DATE_CURRENCY.setName("date");
-        COLUMN_DATE_CURRENCY.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_DATE_CURRENCY.setType(SQLSimpleTypes.Sql99.dateType());
 
         COLUMN_CURRENCY_CURRENCY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CURRENCY_CURRENCY.setName("currency");
-        COLUMN_CURRENCY_CURRENCY.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_CURRENCY_CURRENCY.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_CONVERSION_RATIO_CURRENCY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CONVERSION_RATIO_CURRENCY.setName("conversion_ratio");
-        COLUMN_CONVERSION_RATIO_CURRENCY.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_CONVERSION_RATIO_CURRENCY.setType(SQLSimpleTypes.decimalType(10, 4));
 
         TABLE_CURRENCY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         TABLE_CURRENCY.setName("currency");
         TABLE_CURRENCY.getFeature().addAll(List.of(COLUMN_CURRENCY_ID_CURRENCY, COLUMN_DATE_CURRENCY, COLUMN_CURRENCY_CURRENCY, COLUMN_CONVERSION_RATIO_CURRENCY));
         COLUMN_ACCOUNT_ID_ACCOUNT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ACCOUNT_ID_ACCOUNT.setName("account_id");
-        COLUMN_ACCOUNT_ID_ACCOUNT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ACCOUNT_ID_ACCOUNT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_ACCOUNT_PARENT_ACCOUNT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ACCOUNT_PARENT_ACCOUNT.setName("account_parent");
-        COLUMN_ACCOUNT_PARENT_ACCOUNT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ACCOUNT_PARENT_ACCOUNT.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_ACCOUNT_PARENT_ACCOUNT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_ACCOUNT_DESCRIPTION_ACCOUNT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ACCOUNT_DESCRIPTION_ACCOUNT.setName("account_description");
-        COLUMN_ACCOUNT_DESCRIPTION_ACCOUNT.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_ACCOUNT_DESCRIPTION_ACCOUNT.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_ACCOUNT_DESCRIPTION_ACCOUNT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_ACCOUNT_TYPE_ACCOUNT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ACCOUNT_TYPE_ACCOUNT.setName("account_type");
-        COLUMN_ACCOUNT_TYPE_ACCOUNT.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_ACCOUNT_TYPE_ACCOUNT.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_ACCOUNT_ROLLUP_ACCOUNT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ACCOUNT_ROLLUP_ACCOUNT.setName("account_rollup");
-        COLUMN_ACCOUNT_ROLLUP_ACCOUNT.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_ACCOUNT_ROLLUP_ACCOUNT.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_CUSTOM_MEMBERS_ACCOUNT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOM_MEMBERS_ACCOUNT.setName("Custom_Members");
-        COLUMN_CUSTOM_MEMBERS_ACCOUNT.setType(SqlSimpleTypes.varcharType(255));
+        COLUMN_CUSTOM_MEMBERS_ACCOUNT.setType(SQLSimpleTypes.varcharType(255));
         COLUMN_CUSTOM_MEMBERS_ACCOUNT.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         TABLE_ACCOUNT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
@@ -4555,20 +4557,20 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         TABLE_ACCOUNT.getFeature().addAll(List.of(COLUMN_ACCOUNT_ID_ACCOUNT, COLUMN_ACCOUNT_PARENT_ACCOUNT, COLUMN_ACCOUNT_DESCRIPTION_ACCOUNT, COLUMN_ACCOUNT_TYPE_ACCOUNT, COLUMN_ACCOUNT_ROLLUP_ACCOUNT, COLUMN_CUSTOM_MEMBERS_ACCOUNT));
         COLUMN_CATEGORY_ID_CATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CATEGORY_ID_CATEGORY.setName("category_id");
-        COLUMN_CATEGORY_ID_CATEGORY.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_CATEGORY_ID_CATEGORY.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_CATEGORY_PARENT_CATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CATEGORY_PARENT_CATEGORY.setName("category_parent");
-        COLUMN_CATEGORY_PARENT_CATEGORY.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_CATEGORY_PARENT_CATEGORY.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_CATEGORY_PARENT_CATEGORY.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_CATEGORY_DESCRIPTION_CATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CATEGORY_DESCRIPTION_CATEGORY.setName("category_description");
-        COLUMN_CATEGORY_DESCRIPTION_CATEGORY.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_CATEGORY_DESCRIPTION_CATEGORY.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_CATEGORY_ROLLUP_CATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CATEGORY_ROLLUP_CATEGORY.setName("category_rollup");
-        COLUMN_CATEGORY_ROLLUP_CATEGORY.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_CATEGORY_ROLLUP_CATEGORY.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_CATEGORY_ROLLUP_CATEGORY.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         TABLE_CATEGORY = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
@@ -4576,78 +4578,78 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         TABLE_CATEGORY.getFeature().addAll(List.of(COLUMN_CATEGORY_ID_CATEGORY, COLUMN_CATEGORY_PARENT_CATEGORY, COLUMN_CATEGORY_DESCRIPTION_CATEGORY, COLUMN_CATEGORY_ROLLUP_CATEGORY));
         COLUMN_DAY_DAYS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DAY_DAYS.setName("day");
-        COLUMN_DAY_DAYS.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DAY_DAYS.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_WEEK_DAY_DAYS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WEEK_DAY_DAYS.setName("week_day");
-        COLUMN_WEEK_DAY_DAYS.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_WEEK_DAY_DAYS.setType(SQLSimpleTypes.varcharType(30));
 
         TABLE_DAYS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         TABLE_DAYS.setName("days");
         TABLE_DAYS.getFeature().addAll(List.of(COLUMN_DAY_DAYS, COLUMN_WEEK_DAY_DAYS));
         COLUMN_STORE_ID_EXPENSE_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_ID_EXPENSE_FACT.setName("store_id");
-        COLUMN_STORE_ID_EXPENSE_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_ID_EXPENSE_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_ACCOUNT_ID_EXPENSE_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ACCOUNT_ID_EXPENSE_FACT.setName("account_id");
-        COLUMN_ACCOUNT_ID_EXPENSE_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ACCOUNT_ID_EXPENSE_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_EXP_DATE_EXPENSE_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EXP_DATE_EXPENSE_FACT.setName("exp_date");
-        COLUMN_EXP_DATE_EXPENSE_FACT.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_EXP_DATE_EXPENSE_FACT.setType(SQLSimpleTypes.Sql99.timestampType());
 
         COLUMN_TIME_ID_EXPENSE_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_EXPENSE_FACT.setName("time_id");
-        COLUMN_TIME_ID_EXPENSE_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TIME_ID_EXPENSE_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CATEGORY_ID_EXPENSE_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CATEGORY_ID_EXPENSE_FACT.setName("category_id");
-        COLUMN_CATEGORY_ID_EXPENSE_FACT.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_CATEGORY_ID_EXPENSE_FACT.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_CURRENCY_ID_EXPENSE_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CURRENCY_ID_EXPENSE_FACT.setName("currency_id");
-        COLUMN_CURRENCY_ID_EXPENSE_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CURRENCY_ID_EXPENSE_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_AMOUNT_EXPENSE_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_AMOUNT_EXPENSE_FACT.setName("amount");
-        COLUMN_AMOUNT_EXPENSE_FACT.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_AMOUNT_EXPENSE_FACT.setType(SQLSimpleTypes.decimalType(10, 4));
 
         TABLE_EXPENSE_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         TABLE_EXPENSE_FACT.setName("expense_fact");
         TABLE_EXPENSE_FACT.getFeature().addAll(List.of(COLUMN_STORE_ID_EXPENSE_FACT, COLUMN_ACCOUNT_ID_EXPENSE_FACT, COLUMN_EXP_DATE_EXPENSE_FACT, COLUMN_TIME_ID_EXPENSE_FACT, COLUMN_CATEGORY_ID_EXPENSE_FACT, COLUMN_CURRENCY_ID_EXPENSE_FACT, COLUMN_AMOUNT_EXPENSE_FACT));
         COLUMN_REGION_ID_REGION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_REGION_ID_REGION.setName("region_id");
-        COLUMN_REGION_ID_REGION.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_REGION_ID_REGION.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_SALES_CITY_REGION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_CITY_REGION.setName("sales_city");
-        COLUMN_SALES_CITY_REGION.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_SALES_CITY_REGION.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_SALES_CITY_REGION.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SALES_STATE_PROVINCE_REGION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_STATE_PROVINCE_REGION.setName("sales_state_province");
-        COLUMN_SALES_STATE_PROVINCE_REGION.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_SALES_STATE_PROVINCE_REGION.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_SALES_STATE_PROVINCE_REGION.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SALES_DISTRICT_REGION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_DISTRICT_REGION.setName("sales_district");
-        COLUMN_SALES_DISTRICT_REGION.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_SALES_DISTRICT_REGION.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_SALES_DISTRICT_REGION.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SALES_REGION_REGION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_REGION_REGION.setName("sales_region");
-        COLUMN_SALES_REGION_REGION.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_SALES_REGION_REGION.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_SALES_REGION_REGION.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SALES_COUNTRY_REGION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_COUNTRY_REGION.setName("sales_country");
-        COLUMN_SALES_COUNTRY_REGION.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_SALES_COUNTRY_REGION.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_SALES_COUNTRY_REGION.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SALES_DISTRICT_ID_REGION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALES_DISTRICT_ID_REGION.setName("sales_district_id");
-        COLUMN_SALES_DISTRICT_ID_REGION.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SALES_DISTRICT_ID_REGION.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_SALES_DISTRICT_ID_REGION.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         TABLE_REGION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
@@ -4655,83 +4657,83 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         TABLE_REGION.getFeature().addAll(List.of(COLUMN_REGION_ID_REGION, COLUMN_SALES_CITY_REGION, COLUMN_SALES_STATE_PROVINCE_REGION, COLUMN_SALES_DISTRICT_REGION, COLUMN_SALES_REGION_REGION, COLUMN_SALES_COUNTRY_REGION, COLUMN_SALES_DISTRICT_ID_REGION));
         COLUMN_EMPLOYEE_ID_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EMPLOYEE_ID_RESERVE_EMPLOYEE.setName("employee_id");
-        COLUMN_EMPLOYEE_ID_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_EMPLOYEE_ID_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_FULL_NAME_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FULL_NAME_RESERVE_EMPLOYEE.setName("full_name");
-        COLUMN_FULL_NAME_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_FULL_NAME_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_FIRST_NAME_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FIRST_NAME_RESERVE_EMPLOYEE.setName("first_name");
-        COLUMN_FIRST_NAME_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_FIRST_NAME_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_LAST_NAME_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_LAST_NAME_RESERVE_EMPLOYEE.setName("last_name");
-        COLUMN_LAST_NAME_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_LAST_NAME_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_POSITION_ID_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_POSITION_ID_RESERVE_EMPLOYEE.setName("position_id");
-        COLUMN_POSITION_ID_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_POSITION_ID_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_POSITION_ID_RESERVE_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_POSITION_TITLE_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_POSITION_TITLE_RESERVE_EMPLOYEE.setName("position_title");
-        COLUMN_POSITION_TITLE_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_POSITION_TITLE_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_POSITION_TITLE_RESERVE_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_ID_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_ID_RESERVE_EMPLOYEE.setName("store_id");
-        COLUMN_STORE_ID_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_ID_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DEPARTMENT_ID_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DEPARTMENT_ID_RESERVE_EMPLOYEE.setName("department_id");
-        COLUMN_DEPARTMENT_ID_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DEPARTMENT_ID_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_BIRTH_DATE_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_BIRTH_DATE_RESERVE_EMPLOYEE.setName("birth_date");
-        COLUMN_BIRTH_DATE_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_BIRTH_DATE_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.timestampType());
 
         COLUMN_HIRE_DATE_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_HIRE_DATE_RESERVE_EMPLOYEE.setName("hire_date");
-        COLUMN_HIRE_DATE_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_HIRE_DATE_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_HIRE_DATE_RESERVE_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_END_DATE_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_END_DATE_RESERVE_EMPLOYEE.setName("end_date");
-        COLUMN_END_DATE_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_END_DATE_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_END_DATE_RESERVE_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SALARY_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALARY_RESERVE_EMPLOYEE.setName("salary");
-        COLUMN_SALARY_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_SALARY_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.decimalType(10, 4));
 
         COLUMN_SUPERVISOR_ID_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SUPERVISOR_ID_RESERVE_EMPLOYEE.setName("supervisor_id");
-        COLUMN_SUPERVISOR_ID_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SUPERVISOR_ID_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_SUPERVISOR_ID_RESERVE_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_EDUCATION_LEVEL_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EDUCATION_LEVEL_RESERVE_EMPLOYEE.setName("education_level");
-        COLUMN_EDUCATION_LEVEL_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_EDUCATION_LEVEL_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_MARITAL_STATUS_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MARITAL_STATUS_RESERVE_EMPLOYEE.setName("marital_status");
-        COLUMN_MARITAL_STATUS_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_MARITAL_STATUS_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_GENDER_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GENDER_RESERVE_EMPLOYEE.setName("gender");
-        COLUMN_GENDER_RESERVE_EMPLOYEE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_GENDER_RESERVE_EMPLOYEE.setType(SQLSimpleTypes.varcharType(30));
 
         TABLE_RESERVE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         TABLE_RESERVE_EMPLOYEE.setName("reserve_employee");
         TABLE_RESERVE_EMPLOYEE.getFeature().addAll(List.of(COLUMN_EMPLOYEE_ID_RESERVE_EMPLOYEE, COLUMN_FULL_NAME_RESERVE_EMPLOYEE, COLUMN_FIRST_NAME_RESERVE_EMPLOYEE, COLUMN_LAST_NAME_RESERVE_EMPLOYEE, COLUMN_POSITION_ID_RESERVE_EMPLOYEE, COLUMN_POSITION_TITLE_RESERVE_EMPLOYEE, COLUMN_STORE_ID_RESERVE_EMPLOYEE, COLUMN_DEPARTMENT_ID_RESERVE_EMPLOYEE, COLUMN_BIRTH_DATE_RESERVE_EMPLOYEE, COLUMN_HIRE_DATE_RESERVE_EMPLOYEE, COLUMN_END_DATE_RESERVE_EMPLOYEE, COLUMN_SALARY_RESERVE_EMPLOYEE, COLUMN_SUPERVISOR_ID_RESERVE_EMPLOYEE, COLUMN_EDUCATION_LEVEL_RESERVE_EMPLOYEE, COLUMN_MARITAL_STATUS_RESERVE_EMPLOYEE, COLUMN_GENDER_RESERVE_EMPLOYEE));
         COLUMN_WAREHOUSE_CLASS_ID_WAREHOUSE_CLASS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_CLASS_ID_WAREHOUSE_CLASS.setName("warehouse_class_id");
-        COLUMN_WAREHOUSE_CLASS_ID_WAREHOUSE_CLASS.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_WAREHOUSE_CLASS_ID_WAREHOUSE_CLASS.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DESCRIPTION_WAREHOUSE_CLASS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DESCRIPTION_WAREHOUSE_CLASS.setName("description");
-        COLUMN_DESCRIPTION_WAREHOUSE_CLASS.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_DESCRIPTION_WAREHOUSE_CLASS.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_DESCRIPTION_WAREHOUSE_CLASS.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         TABLE_WAREHOUSE_CLASS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
@@ -4739,225 +4741,225 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         TABLE_WAREHOUSE_CLASS.getFeature().addAll(List.of(COLUMN_WAREHOUSE_CLASS_ID_WAREHOUSE_CLASS, COLUMN_DESCRIPTION_WAREHOUSE_CLASS));
         COLUMN_MI_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MI_CUSTOMER.setName("mi");
-        COLUMN_MI_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_MI_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_MI_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_ADDRESS1_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ADDRESS1_CUSTOMER.setName("address1");
-        COLUMN_ADDRESS1_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_ADDRESS1_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_ADDRESS1_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_ADDRESS3_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ADDRESS3_CUSTOMER.setName("address3");
-        COLUMN_ADDRESS3_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_ADDRESS3_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_ADDRESS3_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_ADDRESS4_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ADDRESS4_CUSTOMER.setName("address4");
-        COLUMN_ADDRESS4_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_ADDRESS4_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_ADDRESS4_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_POSTAL_CODE_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_POSTAL_CODE_CUSTOMER.setName("postal_code");
-        COLUMN_POSTAL_CODE_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_POSTAL_CODE_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_PHONE1_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PHONE1_CUSTOMER.setName("phone1");
-        COLUMN_PHONE1_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_PHONE1_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_PHONE2_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PHONE2_CUSTOMER.setName("phone2");
-        COLUMN_PHONE2_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_PHONE2_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_BIRTHDATE_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_BIRTHDATE_CUSTOMER.setName("birthdate");
-        COLUMN_BIRTHDATE_CUSTOMER.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_BIRTHDATE_CUSTOMER.setType(SQLSimpleTypes.Sql99.dateType());
 
         COLUMN_DATE_ACCNT_OPENED_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DATE_ACCNT_OPENED_CUSTOMER.setName("date_accnt_opened");
-        COLUMN_DATE_ACCNT_OPENED_CUSTOMER.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_DATE_ACCNT_OPENED_CUSTOMER.setType(SQLSimpleTypes.Sql99.dateType());
 
         TABLE_CUSTOMER.getFeature().addAll(List.of(COLUMN_MI_CUSTOMER, COLUMN_ADDRESS1_CUSTOMER, COLUMN_ADDRESS3_CUSTOMER, COLUMN_ADDRESS4_CUSTOMER, COLUMN_POSTAL_CODE_CUSTOMER, COLUMN_PHONE1_CUSTOMER, COLUMN_PHONE2_CUSTOMER, COLUMN_BIRTHDATE_CUSTOMER, COLUMN_DATE_ACCNT_OPENED_CUSTOMER));
         COLUMN_DEPARTMENT_ID_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DEPARTMENT_ID_EMPLOYEE.setName("department_id");
-        COLUMN_DEPARTMENT_ID_EMPLOYEE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DEPARTMENT_ID_EMPLOYEE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_BIRTH_DATE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_BIRTH_DATE_EMPLOYEE.setName("birth_date");
-        COLUMN_BIRTH_DATE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.dateType());
+        COLUMN_BIRTH_DATE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.dateType());
 
         COLUMN_HIRE_DATE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_HIRE_DATE_EMPLOYEE.setName("hire_date");
-        COLUMN_HIRE_DATE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_HIRE_DATE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_HIRE_DATE_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_END_DATE_EMPLOYEE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_END_DATE_EMPLOYEE.setName("end_date");
-        COLUMN_END_DATE_EMPLOYEE.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_END_DATE_EMPLOYEE.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_END_DATE_EMPLOYEE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         TABLE_EMPLOYEE.getFeature().addAll(List.of(COLUMN_DEPARTMENT_ID_EMPLOYEE, COLUMN_BIRTH_DATE_EMPLOYEE, COLUMN_HIRE_DATE_EMPLOYEE, COLUMN_END_DATE_EMPLOYEE));
         COLUMN_MANAGEMENT_ROLE_POSITION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MANAGEMENT_ROLE_POSITION.setName("management_role");
-        COLUMN_MANAGEMENT_ROLE_POSITION.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_MANAGEMENT_ROLE_POSITION.setType(SQLSimpleTypes.varcharType(30));
 
         TABLE_POSITION.getFeature().addAll(List.of(COLUMN_MANAGEMENT_ROLE_POSITION));
         COLUMN_PROMOTION_DISTRICT_ID_PROMOTION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PROMOTION_DISTRICT_ID_PROMOTION.setName("promotion_district_id");
-        COLUMN_PROMOTION_DISTRICT_ID_PROMOTION.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PROMOTION_DISTRICT_ID_PROMOTION.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_PROMOTION_DISTRICT_ID_PROMOTION.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_COST_PROMOTION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COST_PROMOTION.setName("cost");
-        COLUMN_COST_PROMOTION.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_COST_PROMOTION.setType(SQLSimpleTypes.decimalType(10, 4));
         COLUMN_COST_PROMOTION.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_START_DATE_PROMOTION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_START_DATE_PROMOTION.setName("start_date");
-        COLUMN_START_DATE_PROMOTION.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_START_DATE_PROMOTION.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_START_DATE_PROMOTION.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_END_DATE_PROMOTION = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_END_DATE_PROMOTION.setName("end_date");
-        COLUMN_END_DATE_PROMOTION.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_END_DATE_PROMOTION.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_END_DATE_PROMOTION.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         TABLE_PROMOTION.getFeature().addAll(List.of(COLUMN_PROMOTION_DISTRICT_ID_PROMOTION, COLUMN_COST_PROMOTION, COLUMN_START_DATE_PROMOTION, COLUMN_END_DATE_PROMOTION));
         COLUMN_STORE_PHONE_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_PHONE_STORE.setName("store_phone");
-        COLUMN_STORE_PHONE_STORE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_PHONE_STORE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_PHONE_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_FAX_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_FAX_STORE.setName("store_fax");
-        COLUMN_STORE_FAX_STORE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_FAX_STORE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_FAX_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_FIRST_OPENED_DATE_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FIRST_OPENED_DATE_STORE.setName("first_opened_date");
-        COLUMN_FIRST_OPENED_DATE_STORE.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_FIRST_OPENED_DATE_STORE.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_FIRST_OPENED_DATE_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_LAST_REMODEL_DATE_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_LAST_REMODEL_DATE_STORE.setName("last_remodel_date");
-        COLUMN_LAST_REMODEL_DATE_STORE.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_LAST_REMODEL_DATE_STORE.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_LAST_REMODEL_DATE_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_VIDEO_STORE_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_VIDEO_STORE_STORE.setName("video_store");
-        COLUMN_VIDEO_STORE_STORE.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_VIDEO_STORE_STORE.setType(SQLSimpleTypes.Sql99.booleanType());
         COLUMN_VIDEO_STORE_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SALAD_BAR_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALAD_BAR_STORE.setName("salad_bar");
-        COLUMN_SALAD_BAR_STORE.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_SALAD_BAR_STORE.setType(SQLSimpleTypes.Sql99.booleanType());
         COLUMN_SALAD_BAR_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_PREPARED_FOOD_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PREPARED_FOOD_STORE.setName("prepared_food");
-        COLUMN_PREPARED_FOOD_STORE.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_PREPARED_FOOD_STORE.setType(SQLSimpleTypes.Sql99.booleanType());
         COLUMN_PREPARED_FOOD_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_FLORIST_STORE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FLORIST_STORE.setName("florist");
-        COLUMN_FLORIST_STORE.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_FLORIST_STORE.setType(SQLSimpleTypes.Sql99.booleanType());
         COLUMN_FLORIST_STORE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         TABLE_STORE.getFeature().addAll(List.of(COLUMN_STORE_PHONE_STORE, COLUMN_STORE_FAX_STORE, COLUMN_FIRST_OPENED_DATE_STORE, COLUMN_LAST_REMODEL_DATE_STORE, COLUMN_VIDEO_STORE_STORE, COLUMN_SALAD_BAR_STORE, COLUMN_PREPARED_FOOD_STORE, COLUMN_FLORIST_STORE));
         COLUMN_STORE_NUMBER_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_NUMBER_STORE_RAGGED.setName("store_number");
-        COLUMN_STORE_NUMBER_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STORE_NUMBER_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_STORE_NUMBER_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_POSTAL_CODE_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_POSTAL_CODE_STORE_RAGGED.setName("store_postal_code");
-        COLUMN_STORE_POSTAL_CODE_STORE_RAGGED.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_POSTAL_CODE_STORE_RAGGED.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_POSTAL_CODE_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_PHONE_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_PHONE_STORE_RAGGED.setName("store_phone");
-        COLUMN_STORE_PHONE_STORE_RAGGED.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_PHONE_STORE_RAGGED.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_PHONE_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STORE_FAX_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STORE_FAX_STORE_RAGGED.setName("store_fax");
-        COLUMN_STORE_FAX_STORE_RAGGED.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STORE_FAX_STORE_RAGGED.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_STORE_FAX_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_FIRST_OPENED_DATE_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FIRST_OPENED_DATE_STORE_RAGGED.setName("first_opened_date");
-        COLUMN_FIRST_OPENED_DATE_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_FIRST_OPENED_DATE_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_FIRST_OPENED_DATE_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_LAST_REMODEL_DATE_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_LAST_REMODEL_DATE_STORE_RAGGED.setName("last_remodel_date");
-        COLUMN_LAST_REMODEL_DATE_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_LAST_REMODEL_DATE_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_LAST_REMODEL_DATE_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_VIDEO_STORE_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_VIDEO_STORE_STORE_RAGGED.setName("video_store");
-        COLUMN_VIDEO_STORE_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_VIDEO_STORE_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.booleanType());
         COLUMN_VIDEO_STORE_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_SALAD_BAR_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SALAD_BAR_STORE_RAGGED.setName("salad_bar");
-        COLUMN_SALAD_BAR_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_SALAD_BAR_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.booleanType());
         COLUMN_SALAD_BAR_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_PREPARED_FOOD_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PREPARED_FOOD_STORE_RAGGED.setName("prepared_food");
-        COLUMN_PREPARED_FOOD_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_PREPARED_FOOD_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.booleanType());
         COLUMN_PREPARED_FOOD_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_FLORIST_STORE_RAGGED = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_FLORIST_STORE_RAGGED.setName("florist");
-        COLUMN_FLORIST_STORE_RAGGED.setType(SqlSimpleTypes.Sql99.booleanType());
+        COLUMN_FLORIST_STORE_RAGGED.setType(SQLSimpleTypes.Sql99.booleanType());
         COLUMN_FLORIST_STORE_RAGGED.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         TABLE_STORE_RAGGED.getFeature().addAll(List.of(COLUMN_STORE_NUMBER_STORE_RAGGED, COLUMN_STORE_POSTAL_CODE_STORE_RAGGED, COLUMN_STORE_PHONE_STORE_RAGGED, COLUMN_STORE_FAX_STORE_RAGGED, COLUMN_FIRST_OPENED_DATE_STORE_RAGGED, COLUMN_LAST_REMODEL_DATE_STORE_RAGGED, COLUMN_VIDEO_STORE_STORE_RAGGED, COLUMN_SALAD_BAR_STORE_RAGGED, COLUMN_PREPARED_FOOD_STORE_RAGGED, COLUMN_FLORIST_STORE_RAGGED));
         COLUMN_WAREHOUSE_CLASS_ID_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_CLASS_ID_WAREHOUSE.setName("warehouse_class_id");
-        COLUMN_WAREHOUSE_CLASS_ID_WAREHOUSE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_WAREHOUSE_CLASS_ID_WAREHOUSE.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_WAREHOUSE_CLASS_ID_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WA_ADDRESS1_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WA_ADDRESS1_WAREHOUSE.setName("wa_address1");
-        COLUMN_WA_ADDRESS1_WAREHOUSE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_WA_ADDRESS1_WAREHOUSE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_WA_ADDRESS1_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WA_ADDRESS2_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WA_ADDRESS2_WAREHOUSE.setName("wa_address2");
-        COLUMN_WA_ADDRESS2_WAREHOUSE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_WA_ADDRESS2_WAREHOUSE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_WA_ADDRESS2_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WA_ADDRESS3_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WA_ADDRESS3_WAREHOUSE.setName("wa_address3");
-        COLUMN_WA_ADDRESS3_WAREHOUSE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_WA_ADDRESS3_WAREHOUSE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_WA_ADDRESS3_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WA_ADDRESS4_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WA_ADDRESS4_WAREHOUSE.setName("wa_address4");
-        COLUMN_WA_ADDRESS4_WAREHOUSE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_WA_ADDRESS4_WAREHOUSE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_WA_ADDRESS4_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WAREHOUSE_POSTAL_CODE_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_POSTAL_CODE_WAREHOUSE.setName("warehouse_postal_code");
-        COLUMN_WAREHOUSE_POSTAL_CODE_WAREHOUSE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_WAREHOUSE_POSTAL_CODE_WAREHOUSE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_WAREHOUSE_POSTAL_CODE_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WAREHOUSE_OWNER_NAME_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_OWNER_NAME_WAREHOUSE.setName("warehouse_owner_name");
-        COLUMN_WAREHOUSE_OWNER_NAME_WAREHOUSE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_WAREHOUSE_OWNER_NAME_WAREHOUSE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_WAREHOUSE_OWNER_NAME_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WAREHOUSE_PHONE_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_PHONE_WAREHOUSE.setName("warehouse_phone");
-        COLUMN_WAREHOUSE_PHONE_WAREHOUSE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_WAREHOUSE_PHONE_WAREHOUSE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_WAREHOUSE_PHONE_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_WAREHOUSE_FAX_WAREHOUSE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WAREHOUSE_FAX_WAREHOUSE.setName("warehouse_fax");
-        COLUMN_WAREHOUSE_FAX_WAREHOUSE.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_WAREHOUSE_FAX_WAREHOUSE.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_WAREHOUSE_FAX_WAREHOUSE.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         TABLE_WAREHOUSE.getFeature().addAll(List.of(COLUMN_WAREHOUSE_CLASS_ID_WAREHOUSE, COLUMN_WA_ADDRESS1_WAREHOUSE, COLUMN_WA_ADDRESS2_WAREHOUSE, COLUMN_WA_ADDRESS3_WAREHOUSE, COLUMN_WA_ADDRESS4_WAREHOUSE, COLUMN_WAREHOUSE_POSTAL_CODE_WAREHOUSE, COLUMN_WAREHOUSE_OWNER_NAME_WAREHOUSE, COLUMN_WAREHOUSE_PHONE_WAREHOUSE, COLUMN_WAREHOUSE_FAX_WAREHOUSE));
@@ -5254,26 +5256,4 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
                 List.of(new CatalogRef("catalog", this::get)));
     }
 
-    /**
-     * One SQL index over {@code columns} of {@code table}.
-     *
-     * <p>
-     * These describe the database the dataset ships, not anything the mapping
-     * reads: without them the loaded schema has no index at all, and every
-     * query against 876042 rows is a scan. They are created after the rows are
-     * loaded, so an insert does not maintain them one at a time.
-     */
-    private static org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLIndex index(String name, boolean unique, org.eclipse.daanse.cwm.model.cwm.resource.relational.Table table,
-            org.eclipse.daanse.cwm.model.cwm.resource.relational.Column... columns) {
-        org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLIndex idx = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createSQLIndex();
-        idx.setName(name);
-        idx.setIsUnique(unique);
-        idx.setSpannedClass(table);
-        for (org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column : columns) {
-            org.eclipse.daanse.cwm.model.cwm.foundation.keysindexes.IndexedFeature feature = org.eclipse.daanse.cwm.model.cwm.foundation.keysindexes.KeysindexesFactory.eINSTANCE.createIndexedFeature();
-            feature.setFeature(column);
-            idx.getIndexedFeature().add(feature);
-        }
-        return idx;
-    }
 }

--- a/instance/emf/complex/parcel/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/parcel/CatalogSupplier.java
+++ b/instance/emf/complex/parcel/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/parcel/CatalogSupplier.java
@@ -49,7 +49,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.COMPLEX, source = Source.EMF, number = "99.1.6", group = "Full Examples")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -226,110 +226,110 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         // Initialize Parcels (Fact) columns
         COLUMN_PARCEL_ID_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PARCEL_ID_FACT.setName("parcel_id");
-        COLUMN_PARCEL_ID_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PARCEL_ID_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_WIDTH_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WIDTH_FACT.setName("width");
-        COLUMN_WIDTH_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_WIDTH_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_DEPTH_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DEPTH_FACT.setName("depth");
-        COLUMN_DEPTH_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_DEPTH_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_HEIGHT_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_HEIGHT_FACT.setName("height");
-        COLUMN_HEIGHT_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_HEIGHT_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_TYPE_ID_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TYPE_ID_FACT.setName("type_id");
-        COLUMN_TYPE_ID_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TYPE_ID_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DEFECT_ID_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DEFECT_ID_FACT.setName("defect_id");
-        COLUMN_DEFECT_ID_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DEFECT_ID_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DELIVERABLE_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DELIVERABLE_FACT.setName("deliverable");
-        COLUMN_DELIVERABLE_FACT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_DELIVERABLE_FACT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_CUSTOMS_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMS_FACT.setName("customs");
-        COLUMN_CUSTOMS_FACT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CUSTOMS_FACT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_RETURN_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_RETURN_FACT.setName("return_status");
-        COLUMN_RETURN_FACT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_RETURN_FACT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_SENDER_ID_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SENDER_ID_FACT.setName("sender_id");
-        COLUMN_SENDER_ID_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_SENDER_ID_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_RECEIVER_ID_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_RECEIVER_ID_FACT.setName("receiver_id");
-        COLUMN_RECEIVER_ID_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_RECEIVER_ID_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DROP_OFF_ID_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DROP_OFF_ID_FACT.setName("drop_off_id");
-        COLUMN_DROP_OFF_ID_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DROP_OFF_ID_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DELIVERY_ID_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DELIVERY_ID_FACT.setName("delivery_id");
-        COLUMN_DELIVERY_ID_FACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DELIVERY_ID_FACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_POSTAGE_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_POSTAGE_FACT.setName("postage");
-        COLUMN_POSTAGE_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_POSTAGE_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_INSURANCE_VALUE_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_INSURANCE_VALUE_FACT.setName("insurance_value");
-        COLUMN_INSURANCE_VALUE_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_INSURANCE_VALUE_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         COLUMN_WEIGHT_FACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_WEIGHT_FACT.setName("weight");
-        COLUMN_WEIGHT_FACT.setType(SqlSimpleTypes.decimalType(18, 4));
+        COLUMN_WEIGHT_FACT.setType(SQLSimpleTypes.decimalType(18, 4));
 
         // Initialize Parcel Type Table columns
         COLUMN_TYPE_ID_TYPE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TYPE_ID_TYPE.setName("type_id");
-        COLUMN_TYPE_ID_TYPE.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TYPE_ID_TYPE.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_TYPE_NAME_TYPE = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TYPE_NAME_TYPE.setName("type_name");
-        COLUMN_TYPE_NAME_TYPE.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_TYPE_NAME_TYPE.setType(SQLSimpleTypes.Sql99.varcharType());
 
         // Initialize Defect Table columns
         COLUMN_DEFECT_ID_DEFECT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DEFECT_ID_DEFECT.setName("defect_id");
-        COLUMN_DEFECT_ID_DEFECT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_DEFECT_ID_DEFECT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_DEFECT_NAME_DEFECT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_DEFECT_NAME_DEFECT.setName("defect_name");
-        COLUMN_DEFECT_NAME_DEFECT.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_DEFECT_NAME_DEFECT.setType(SQLSimpleTypes.Sql99.varcharType());
 
         // Initialize Address Table columns
         COLUMN_ADDRESS_ID_ADDRESS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ADDRESS_ID_ADDRESS.setName("address_id");
-        COLUMN_ADDRESS_ID_ADDRESS.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ADDRESS_ID_ADDRESS.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CONTINENT_ADDRESS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CONTINENT_ADDRESS.setName("continent");
-        COLUMN_CONTINENT_ADDRESS.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CONTINENT_ADDRESS.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_COUNTRY_ADDRESS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COUNTRY_ADDRESS.setName("country");
-        COLUMN_COUNTRY_ADDRESS.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_COUNTRY_ADDRESS.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_CITY_ADDRESS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CITY_ADDRESS.setName("city");
-        COLUMN_CITY_ADDRESS.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_CITY_ADDRESS.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_POSTAL_CODE_ADDRESS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_POSTAL_CODE_ADDRESS.setName("postal_code");
-        COLUMN_POSTAL_CODE_ADDRESS.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_POSTAL_CODE_ADDRESS.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_STREET_ADDRESS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STREET_ADDRESS.setName("street");
-        COLUMN_STREET_ADDRESS.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_STREET_ADDRESS.setType(SQLSimpleTypes.Sql99.varcharType());
 
         // Initialize tables
         TABLE_PARCELS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();

--- a/instance/emf/complex/population.jena/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/population/jena/CatalogSupplier.java
+++ b/instance/emf/complex/population.jena/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/population/jena/CatalogSupplier.java
@@ -53,7 +53,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.enumerations.NullableType;
 @MappingInstance(kind = Kind.COMPLEX, source = Source.EMF, number = "99.1.3", group = "Full Examples")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
@@ -230,151 +230,151 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         // Initialize Einwohner (Fact) columns
         COLUMN_JAHR_EINWOHNER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_JAHR_EINWOHNER.setName("JAHR");
-        COLUMN_JAHR_EINWOHNER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_JAHR_EINWOHNER.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STATBEZ_EINWOHNER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STATBEZ_EINWOHNER.setName("STATBEZ");
-        COLUMN_STATBEZ_EINWOHNER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_STATBEZ_EINWOHNER.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_KER_GESCH_EINWOHNER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_KER_GESCH_EINWOHNER.setName("KER_GESCH");
-        COLUMN_KER_GESCH_EINWOHNER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_KER_GESCH_EINWOHNER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_AGE_EINWOHNER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_AGE_EINWOHNER.setName("AGE");
-        COLUMN_AGE_EINWOHNER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_AGE_EINWOHNER.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_ANZAHL_EINWOHNER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ANZAHL_EINWOHNER.setName("Anzahl");
-        COLUMN_ANZAHL_EINWOHNER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ANZAHL_EINWOHNER.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_GEOJSON_EINWOHNER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GEOJSON_EINWOHNER.setName("geojson");
-        COLUMN_GEOJSON_EINWOHNER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_GEOJSON_EINWOHNER.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_GEOJSON_EINWOHNER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Initialize Year Table columns
         COLUMN_YEAR_YEAR = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_YEAR_YEAR.setName("year");
-        COLUMN_YEAR_YEAR.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_YEAR_YEAR.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_ORDINAL_YEAR = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ORDINAL_YEAR.setName("ordinal");
-        COLUMN_ORDINAL_YEAR.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ORDINAL_YEAR.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Initialize Town Table columns
         COLUMN_ID_TOWN = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ID_TOWN.setName("id");
-        COLUMN_ID_TOWN.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ID_TOWN.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_NAME_TOWN = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_NAME_TOWN.setName("name");
-        COLUMN_NAME_TOWN.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_NAME_TOWN.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_GEOJSON_TOWN = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GEOJSON_TOWN.setName("geojson");
-        COLUMN_GEOJSON_TOWN.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_GEOJSON_TOWN.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_GEOJSON_TOWN.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Initialize Plraum Table columns
         COLUMN_GID_PLRAUM = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GID_PLRAUM.setName("gid");
-        COLUMN_GID_PLRAUM.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_GID_PLRAUM.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PLRAUM_PLRAUM = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PLRAUM_PLRAUM.setName("plraum");
-        COLUMN_PLRAUM_PLRAUM.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_PLRAUM_PLRAUM.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_UUID_PLRAUM = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UUID_PLRAUM.setName("uuid");
-        COLUMN_UUID_PLRAUM.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_UUID_PLRAUM.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_UUID_PLRAUM.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_GEOJSON_PLRAUM = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GEOJSON_PLRAUM.setName("geojson");
-        COLUMN_GEOJSON_PLRAUM.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_GEOJSON_PLRAUM.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_GEOJSON_PLRAUM.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_TOWNID_PLRAUM = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TOWNID_PLRAUM.setName("townid");
-        COLUMN_TOWNID_PLRAUM.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_TOWNID_PLRAUM.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Initialize Statbez Table columns
         COLUMN_GID_STATBEZ = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GID_STATBEZ.setName("gid");
-        COLUMN_GID_STATBEZ.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_GID_STATBEZ.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PLRAUM_STATBEZ = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PLRAUM_STATBEZ.setName("plraum");
-        COLUMN_PLRAUM_STATBEZ.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_PLRAUM_STATBEZ.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_STATBEZ_NAME_STATBEZ = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STATBEZ_NAME_STATBEZ.setName("statbez_name");
-        COLUMN_STATBEZ_NAME_STATBEZ.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_STATBEZ_NAME_STATBEZ.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_UUID_STATBEZ = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_UUID_STATBEZ.setName("uuid");
-        COLUMN_UUID_STATBEZ.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_UUID_STATBEZ.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_UUID_STATBEZ.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_GEOJSON_STATBEZ = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_GEOJSON_STATBEZ.setName("geojson");
-        COLUMN_GEOJSON_STATBEZ.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_GEOJSON_STATBEZ.setType(SQLSimpleTypes.Sql99.varcharType());
         COLUMN_GEOJSON_STATBEZ.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Initialize Gender Table columns
         COLUMN_KEY_GENDER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_KEY_GENDER.setName("key");
-        COLUMN_KEY_GENDER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_KEY_GENDER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_NAME_GENDER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_NAME_GENDER.setName("name");
-        COLUMN_NAME_GENDER.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_NAME_GENDER.setType(SQLSimpleTypes.Sql99.varcharType());
 
         // Initialize Age Groups Table columns
         COLUMN_AGE_AGEGROUPS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_AGE_AGEGROUPS.setName("Age");
-        COLUMN_AGE_AGEGROUPS.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_AGE_AGEGROUPS.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_H1_AGEGROUPS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_H1_AGEGROUPS.setName("H1");
-        COLUMN_H1_AGEGROUPS.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_H1_AGEGROUPS.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_H1_ORDER_AGEGROUPS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_H1_ORDER_AGEGROUPS.setName("H1_Order");
-        COLUMN_H1_ORDER_AGEGROUPS.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_H1_ORDER_AGEGROUPS.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_H2_AGEGROUPS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_H2_AGEGROUPS.setName("H2");
-        COLUMN_H2_AGEGROUPS.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_H2_AGEGROUPS.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_H2_ORDER_AGEGROUPS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_H2_ORDER_AGEGROUPS.setName("H2_Order");
-        COLUMN_H2_ORDER_AGEGROUPS.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_H2_ORDER_AGEGROUPS.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_H7_AGEGROUPS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_H7_AGEGROUPS.setName("H7");
-        COLUMN_H7_AGEGROUPS.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_H7_AGEGROUPS.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_H7_ORDER_AGEGROUPS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_H7_ORDER_AGEGROUPS.setName("H7_Order");
-        COLUMN_H7_ORDER_AGEGROUPS.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_H7_ORDER_AGEGROUPS.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_H8_AGEGROUPS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_H8_AGEGROUPS.setName("H8");
-        COLUMN_H8_AGEGROUPS.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_H8_AGEGROUPS.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_H8_ORDER_AGEGROUPS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_H8_ORDER_AGEGROUPS.setName("H8_Order");
-        COLUMN_H8_ORDER_AGEGROUPS.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_H8_ORDER_AGEGROUPS.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_H9_AGEGROUPS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_H9_AGEGROUPS.setName("H9");
-        COLUMN_H9_AGEGROUPS.setType(SqlSimpleTypes.Sql99.varcharType());
+        COLUMN_H9_AGEGROUPS.setType(SQLSimpleTypes.Sql99.varcharType());
 
         COLUMN_H9_ORDER_AGEGROUPS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_H9_ORDER_AGEGROUPS.setName("H9_Order");
-        COLUMN_H9_ORDER_AGEGROUPS.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_H9_ORDER_AGEGROUPS.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Initialize tables
         TABLE_EINWOHNER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();

--- a/instance/emf/complex/school/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/school/CatalogSupplier.java
+++ b/instance/emf/complex/school/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/school/CatalogSupplier.java
@@ -44,7 +44,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = CatalogMappingSupplier.class)
 @MappingInstance(kind = Kind.COMPLEX, number = "99.1.1", source = Source.EMF, group = "Full Examples") // NOSONAR
 
@@ -106,27 +106,27 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,INTEGER,VARCHAR,INTEGER,INTEGER,INTEGER
         Column columnIdInSchuleTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInSchuleTable.setName("id");
-        columnIdInSchuleTable.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInSchuleTable.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnSchulNameInSchuleTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchulNameInSchuleTable.setName(COL_NAME_SCHUL_NAME);
-        columnSchulNameInSchuleTable.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnSchulNameInSchuleTable.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnSchulNummerInSchuleTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchulNummerInSchuleTable.setName(COL_NAME_SCHUL_NUMMER);
-        columnSchulNummerInSchuleTable.setType(SqlSimpleTypes.Sql99.integerType());
+        columnSchulNummerInSchuleTable.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnGanztagsArtIdInSchuleTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnGanztagsArtIdInSchuleTable.setName("ganztags_art_id");
-        columnGanztagsArtIdInSchuleTable.setType(SqlSimpleTypes.Sql99.integerType());
+        columnGanztagsArtIdInSchuleTable.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnTraegerIdInSchuleTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTraegerIdInSchuleTable.setName("traeger_id");
-        columnTraegerIdInSchuleTable.setType(SqlSimpleTypes.Sql99.integerType());
+        columnTraegerIdInSchuleTable.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnSchulArtIdInSchuleTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchulArtIdInSchuleTable.setName("schul_art_id");
-        columnSchulArtIdInSchuleTable.setType(SqlSimpleTypes.Sql99.integerType());
+        columnSchulArtIdInSchuleTable.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table tableSchule = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableSchule.setName(TAB_NAME_SCHULE);
@@ -138,11 +138,11 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR
         Column columnIdInGanztagsArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInGanztagsArt.setName("id");
-        columnIdInGanztagsArt.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInGanztagsArt.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnSchulUmfangInGanztagsArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchulUmfangInGanztagsArt.setName("schul_umfang");
-        columnSchulUmfangInGanztagsArt.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnSchulUmfangInGanztagsArt.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableGanztagsArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableGanztagsArt.setName("ganztags_art");
@@ -152,15 +152,15 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR,INTEGER
         Column columnIdInTraegerTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInTraegerTable.setName("id");
-        columnIdInTraegerTable.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInTraegerTable.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnTraegerNameInTraegerTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTraegerNameInTraegerTable.setName("traeger_name");
-        columnTraegerNameInTraegerTable.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnTraegerNameInTraegerTable.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnTraegerArtIdInTraegerTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTraegerArtIdInTraegerTable.setName("traeger_art_id");
-        columnTraegerArtIdInTraegerTable.setType(SqlSimpleTypes.Sql99.integerType());
+        columnTraegerArtIdInTraegerTable.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table tableTraeger = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableTraeger.setName("traeger");
@@ -171,15 +171,15 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR,VARCHAR
         Column columnIdInTraegerArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInTraegerArt.setName("id");
-        columnIdInTraegerArt.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInTraegerArt.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnTraegerArtInTraegerArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTraegerArtInTraegerArt.setName(COL_NAME_TRAEGER_ART);
-        columnTraegerArtInTraegerArt.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnTraegerArtInTraegerArt.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnTraegerKatIdInTraegerArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTraegerKatIdInTraegerArt.setName("traeger_kat_id");
-        columnTraegerKatIdInTraegerArt.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnTraegerKatIdInTraegerArt.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableTraegerArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableTraegerArt.setName(COL_NAME_TRAEGER_ART);
@@ -190,11 +190,11 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR
         Column columnIdInTraegerKategorie = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInTraegerKategorie.setName("id");
-        columnIdInTraegerKategorie.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInTraegerKategorie.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnTraegerKategorieInTraegerKategorie = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTraegerKategorieInTraegerKategorie.setName(COL_NAME_TRAEGER_KATEGORIE);
-        columnTraegerKategorieInTraegerKategorie.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnTraegerKategorieInTraegerKategorie.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableTraegerKategorie = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableTraegerKategorie.setName(COL_NAME_TRAEGER_KATEGORIE);
@@ -209,21 +209,21 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // local to the level-mapping below as a single source of truth.
         Column columnSchulKategorieInScheduleArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchulKategorieInScheduleArt.setName("schul_kategorie_id");
-        columnSchulKategorieInScheduleArt.setType(SqlSimpleTypes.Sql99.integerType());
+        columnSchulKategorieInScheduleArt.setType(SQLSimpleTypes.Sql99.integerType());
 
         // "id","schul_jahr","order"
-        // SqlSimpleTypes.Sql99.integerType(),SqlSimpleTypes.Sql99.varcharType(),SqlSimpleTypes.Sql99.integerType()
+        // SQLSimpleTypes.Sql99.integerType(),SQLSimpleTypes.Sql99.varcharType(),SQLSimpleTypes.Sql99.integerType()
         Column columnIdInSchulJahr = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInSchulJahr.setName("id");
-        columnIdInSchulJahr.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInSchulJahr.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnSchulJahrInSchulJahr = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchulJahrInSchulJahr.setName(COL_NAME_SCHUL_JAHR);
-        columnSchulJahrInSchulJahr.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnSchulJahrInSchulJahr.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnOrderInSchulJahr = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnOrderInSchulJahr.setName("order");
-        columnOrderInSchulJahr.setType(SqlSimpleTypes.Sql99.integerType());
+        columnOrderInSchulJahr.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table tableSchulJahr = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableSchulJahr.setName(COL_NAME_SCHUL_JAHR);
@@ -234,11 +234,11 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR
         Column columnIdInAltersGruppe = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInAltersGruppe.setName("id");
-        columnIdInAltersGruppe.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInAltersGruppe.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnAltersgruppeInAltersGruppe = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnAltersgruppeInAltersGruppe.setName("altersgruppe");
-        columnAltersgruppeInAltersGruppe.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnAltersgruppeInAltersGruppe.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableAltersGruppe = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableAltersGruppe.setName("alters_gruppe");
@@ -248,11 +248,11 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR,VARCHAR
         Column columnIdInGeschlecht = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInGeschlecht.setName("id");
-        columnIdInGeschlecht.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInGeschlecht.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnBezeichnungInGeschlecht = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnBezeichnungInGeschlecht.setName(COL_NAME_BEZEICHNUNG);
-        columnBezeichnungInGeschlecht.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnBezeichnungInGeschlecht.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableGeschlecht = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableGeschlecht.setName("geschlecht");
@@ -260,11 +260,11 @@ public class CatalogSupplier implements CatalogMappingSupplier {
 
         Column columnIdInEinschulung = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInEinschulung.setName("id");
-        columnIdInEinschulung.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInEinschulung.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnEinschulungInEinschulung = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnEinschulungInEinschulung.setName(COL_NAME_EINSCHULUNG2);
-        columnEinschulungInEinschulung.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnEinschulungInEinschulung.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableEinschulung = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableEinschulung.setName(COL_NAME_EINSCHULUNG2);
@@ -274,10 +274,10 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR
         Column columnIdInKlassenWiederholung = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInKlassenWiederholung.setName("id");
-        columnIdInKlassenWiederholung.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInKlassenWiederholung.setType(SQLSimpleTypes.Sql99.integerType());
         Column columnKlassenwiedlerholungInKlassenWiederholung = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnKlassenwiedlerholungInKlassenWiederholung.setName("klassenwiederholung");
-        columnKlassenwiedlerholungInKlassenWiederholung.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnKlassenwiedlerholungInKlassenWiederholung.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableKlassenWiederholung = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableKlassenWiederholung.setName("klassen_wiederholung");
@@ -288,11 +288,11 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR
         Column columnIdInSchulAbschluss = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInSchulAbschluss.setName("id");
-        columnIdInSchulAbschluss.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInSchulAbschluss.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnSchulabschlussInSchulAbschluss = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchulabschlussInSchulAbschluss.setName("schulabschluss");
-        columnSchulabschlussInSchulAbschluss.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnSchulabschlussInSchulAbschluss.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableSchulAbschluss = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableSchulAbschluss.setName("schul_abschluss");
@@ -303,11 +303,11 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR
         Column columnIdInMigrationsHintergrund = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInMigrationsHintergrund.setName("id");
-        columnIdInMigrationsHintergrund.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInMigrationsHintergrund.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnMigrationsHintergrundInMigrationsHintergrund = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnMigrationsHintergrundInMigrationsHintergrund.setName(MIGRATIONS_HINTERGRUND);
-        columnMigrationsHintergrundInMigrationsHintergrund.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnMigrationsHintergrundInMigrationsHintergrund.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableMigrationsHintergrund = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableMigrationsHintergrund.setName(MIGRATIONS_HINTERGRUND);
@@ -318,15 +318,15 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR,VARCHAR,INTEGER
         Column columnIdInWohnortLandkreis = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInWohnortLandkreis.setName("id");
-        columnIdInWohnortLandkreis.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInWohnortLandkreis.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnBezeichnungInWohnortLandkreis = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnBezeichnungInWohnortLandkreis.setName(COL_NAME_BEZEICHNUNG);
-        columnBezeichnungInWohnortLandkreis.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnBezeichnungInWohnortLandkreis.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnBundeslandIdInWohnortLandkreis = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnBundeslandIdInWohnortLandkreis.setName("bundesland_id");
-        columnBundeslandIdInWohnortLandkreis.setType(SqlSimpleTypes.Sql99.integerType());
+        columnBundeslandIdInWohnortLandkreis.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table tableWohnortLandkreis = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableWohnortLandkreis.setName(COL_NAME_WOHNORT_LANDKREIS);
@@ -337,11 +337,11 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR,INTEGER
         Column columnIdInSchulArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInSchulArt.setName("id");
-        columnIdInSchulArt.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInSchulArt.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnSchulartNameInSchulArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchulartNameInSchulArt.setName("schulart_name");
-        columnSchulartNameInSchulArt.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnSchulartNameInSchulArt.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableSchulArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableSchulArt.setName("schul_art");
@@ -352,11 +352,11 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR
         Column columnIdInSchulKategorie = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInSchulKategorie.setName("id");
-        columnIdInSchulKategorie.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInSchulKategorie.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnSchulKategorieNameInSchulKategorie = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchulKategorieNameInSchulKategorie.setName("schul_kategorie_name");
-        columnSchulKategorieNameInSchulKategorie.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnSchulKategorieNameInSchulKategorie.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableSchulKategorie = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableSchulKategorie.setName("schul_kategorie");
@@ -367,15 +367,15 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR,INTEGER,
         Column columnIdInFoerderungArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInFoerderungArt.setName("id");
-        columnIdInFoerderungArt.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInFoerderungArt.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnFoerderungArtInFoerderungArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnFoerderungArtInFoerderungArt.setName(COL_NAME_FOERDERUNG_ART);
-        columnFoerderungArtInFoerderungArt.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnFoerderungArtInFoerderungArt.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnSpFoerderbedarfIdInFoerderungArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSpFoerderbedarfIdInFoerderungArt.setName("sp_foerderbedarf_id");
-        columnSpFoerderbedarfIdInFoerderungArt.setType(SqlSimpleTypes.Sql99.integerType());
+        columnSpFoerderbedarfIdInFoerderungArt.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table tableFoerderungArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableFoerderungArt.setName(COL_NAME_FOERDERUNG_ART);
@@ -386,11 +386,11 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR,,,,,,,,,,,,,,,,,INTEGER,VARCHAR
         Column columnIdInPersonalArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInPersonalArt.setName("id");
-        columnIdInPersonalArt.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInPersonalArt.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnBezeichnungInPersonalArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnBezeichnungInPersonalArt.setName(COL_NAME_BEZEICHNUNG);
-        columnBezeichnungInPersonalArt.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnBezeichnungInPersonalArt.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tablePersonalArt = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tablePersonalArt.setName("personal_art");
@@ -400,11 +400,11 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,VARCHAR,VARCHAR
         Column columnIdInBundesland = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInBundesland.setName("id");
-        columnIdInBundesland.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInBundesland.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnBezeichnungInBundesland = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnBezeichnungInBundesland.setName(COL_NAME_BEZEICHNUNG);
-        columnBezeichnungInBundesland.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnBezeichnungInBundesland.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableBundesland = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableBundesland.setName("bundesland");
@@ -412,11 +412,11 @@ public class CatalogSupplier implements CatalogMappingSupplier {
 
         Column columnIdInSonderpaedFoerderbedart = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnIdInSonderpaedFoerderbedart.setName("id");
-        columnIdInSonderpaedFoerderbedart.setType(SqlSimpleTypes.Sql99.integerType());
+        columnIdInSonderpaedFoerderbedart.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnSonderpaedBedarfInSonderpaedFoerderbedart = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSonderpaedBedarfInSonderpaedFoerderbedart.setName("sonderpaed_bedarf");
-        columnSonderpaedBedarfInSonderpaedFoerderbedart.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnSonderpaedBedarfInSonderpaedFoerderbedart.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableSonderpaedFoerderbedart = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableSonderpaedFoerderbedart.setName("sonderpaed_foerderbedarf");
@@ -427,19 +427,19 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,INTEGER,INTEGER,INTEGER
         Column columnSchuleIdInFactSchulen = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchuleIdInFactSchulen.setName(COL_NAME_SCHULE_ID);
-        columnSchuleIdInFactSchulen.setType(SqlSimpleTypes.Sql99.integerType());
+        columnSchuleIdInFactSchulen.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnSchulJahrIdInFactSchulen = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchulJahrIdInFactSchulen.setName(COL_NAME_SCHUL_JAHR_ID);
-        columnSchulJahrIdInFactSchulen.setType(SqlSimpleTypes.Sql99.integerType());
+        columnSchulJahrIdInFactSchulen.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnAnzahlSchulenInFactSchulen = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnAnzahlSchulenInFactSchulen.setName("anzahl_schulen");
-        columnAnzahlSchulenInFactSchulen.setType(SqlSimpleTypes.Sql99.integerType());
+        columnAnzahlSchulenInFactSchulen.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnAnzahlKlassenInFactSchulen = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnAnzahlKlassenInFactSchulen.setName("anzahl_klassen");
-        columnAnzahlKlassenInFactSchulen.setType(SqlSimpleTypes.Sql99.integerType());
+        columnAnzahlKlassenInFactSchulen.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table tableFactSchulen = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableFactSchulen.setName("fact_schulen");
@@ -450,27 +450,27 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,INTEGER,INTEGER,INTEGER,INTEGER,INTEGER
         Column columnSchuleIdInFactPersonal = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchuleIdInFactPersonal.setName(COL_NAME_SCHULE_ID);
-        columnSchuleIdInFactPersonal.setType(SqlSimpleTypes.Sql99.integerType());
+        columnSchuleIdInFactPersonal.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnSchulJahrIdInFactPersonal = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchulJahrIdInFactPersonal.setName(COL_NAME_SCHUL_JAHR_ID);
-        columnSchulJahrIdInFactPersonal.setType(SqlSimpleTypes.Sql99.integerType());
+        columnSchulJahrIdInFactPersonal.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnAltersGroupIdInFactPersonal = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnAltersGroupIdInFactPersonal.setName("alters_gruppe_id");
-        columnAltersGroupIdInFactPersonal.setType(SqlSimpleTypes.Sql99.integerType());
+        columnAltersGroupIdInFactPersonal.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnGeschlechtIdInFactPersonal = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnGeschlechtIdInFactPersonal.setName("geschlecht_id");
-        columnGeschlechtIdInFactPersonal.setType(SqlSimpleTypes.Sql99.integerType());
+        columnGeschlechtIdInFactPersonal.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnPersonalArtIdInFactPersonal = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnPersonalArtIdInFactPersonal.setName("personal_art_id");
-        columnPersonalArtIdInFactPersonal.setType(SqlSimpleTypes.Sql99.integerType());
+        columnPersonalArtIdInFactPersonal.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnAnzahlPersonenInFactPersonal = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnAnzahlPersonenInFactPersonal.setName("anzahl_personen");
-        columnAnzahlPersonenInFactPersonal.setType(SqlSimpleTypes.Sql99.integerType());
+        columnAnzahlPersonenInFactPersonal.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table tableFactPersonal = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableFactPersonal.setName("fact_personal");
@@ -483,43 +483,43 @@ public class CatalogSupplier implements CatalogMappingSupplier {
         // INTEGER,INTEGER,INTEGER,INTEGER,INTEGER,INTEGER,INTEGER,INTEGER,INTEGER,INTEGER
         Column columnSchuleIdInFactSchueler = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchuleIdInFactSchueler.setName(COL_NAME_SCHULE_ID);
-        columnSchuleIdInFactSchueler.setType(SqlSimpleTypes.Sql99.integerType());
+        columnSchuleIdInFactSchueler.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnSchulJahrIdInFactSchueler = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchulJahrIdInFactSchueler.setName(COL_NAME_SCHUL_JAHR_ID);
-        columnSchulJahrIdInFactSchueler.setType(SqlSimpleTypes.Sql99.integerType());
+        columnSchulJahrIdInFactSchueler.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnGeschlechtIdInFactSchueler = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnGeschlechtIdInFactSchueler.setName("geschlecht_id");
-        columnGeschlechtIdInFactSchueler.setType(SqlSimpleTypes.Sql99.integerType());
+        columnGeschlechtIdInFactSchueler.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnWohnLkIdInFactSchueler = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnWohnLkIdInFactSchueler.setName("wohn_lk_id");
-        columnWohnLkIdInFactSchueler.setType(SqlSimpleTypes.Sql99.integerType());
+        columnWohnLkIdInFactSchueler.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnEinschulungIdInFactSchueler = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnEinschulungIdInFactSchueler.setName("einschulung_id");
-        columnEinschulungIdInFactSchueler.setType(SqlSimpleTypes.Sql99.integerType());
+        columnEinschulungIdInFactSchueler.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnSchulAbschlussIdInFactSchueler = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnSchulAbschlussIdInFactSchueler.setName("schul_abschluss_id");
-        columnSchulAbschlussIdInFactSchueler.setType(SqlSimpleTypes.Sql99.integerType());
+        columnSchulAbschlussIdInFactSchueler.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnKlassenWdhInFactSchueler = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnKlassenWdhInFactSchueler.setName("klassen_wdh");
-        columnKlassenWdhInFactSchueler.setType(SqlSimpleTypes.Sql99.integerType());
+        columnKlassenWdhInFactSchueler.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnMigrationsHgIdInFactSchueler = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnMigrationsHgIdInFactSchueler.setName("migrations_hg_id");
-        columnMigrationsHgIdInFactSchueler.setType(SqlSimpleTypes.Sql99.integerType());
+        columnMigrationsHgIdInFactSchueler.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnFoerderArtIdInFactSchueler = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnFoerderArtIdInFactSchueler.setName("foerder_art_id");
-        columnFoerderArtIdInFactSchueler.setType(SqlSimpleTypes.Sql99.integerType());
+        columnFoerderArtIdInFactSchueler.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnAnzahlSchuelerInFactSchueler = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnAnzahlSchuelerInFactSchueler.setName("anzahl_schueler");
-        columnAnzahlSchuelerInFactSchueler.setType(SqlSimpleTypes.Sql99.integerType());
+        columnAnzahlSchuelerInFactSchueler.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table tableFactSchueler = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableFactSchueler.setName("fact_schueler");

--- a/instance/emf/complex/steelwheels/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/steelwheels/CatalogSupplier.java
+++ b/instance/emf/complex/steelwheels/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/complex/steelwheels/CatalogSupplier.java
@@ -49,7 +49,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.enumerations.NullableType;
 @MappingInstance(kind = Kind.COMPLEX, source = Source.EMF, number = "99.1.5", group = "Full Examples")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
@@ -265,225 +265,225 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         // Initialize Order Fact columns
         COLUMN_CUSTOMERNUMBER_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMERNUMBER_ORDERFACT.setName("CUSTOMERNUMBER");
-        COLUMN_CUSTOMERNUMBER_ORDERFACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMERNUMBER_ORDERFACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_PRODUCTCODE_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCTCODE_ORDERFACT.setName("PRODUCTCODE");
-        COLUMN_PRODUCTCODE_ORDERFACT.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_PRODUCTCODE_ORDERFACT.setType(SQLSimpleTypes.varcharType(60));
 
         COLUMN_TIME_ID_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_ORDERFACT.setName("TIME_ID");
-        COLUMN_TIME_ID_ORDERFACT.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_TIME_ID_ORDERFACT.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_QUANTITYORDERED_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_QUANTITYORDERED_ORDERFACT.setName("QUANTITYORDERED");
-        COLUMN_QUANTITYORDERED_ORDERFACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_QUANTITYORDERED_ORDERFACT.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_TOTALPRICE_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TOTALPRICE_ORDERFACT.setName("TOTALPRICE");
-        COLUMN_TOTALPRICE_ORDERFACT.setType(SqlSimpleTypes.numericType(18, 4));
+        COLUMN_TOTALPRICE_ORDERFACT.setType(SQLSimpleTypes.numericType(18, 4));
 
         COLUMN_STATUS_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STATUS_ORDERFACT.setName("STATUS");
-        COLUMN_STATUS_ORDERFACT.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STATUS_ORDERFACT.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_ORDERDATE_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ORDERDATE_ORDERFACT.setName("ORDERDATE");
-        COLUMN_ORDERDATE_ORDERFACT.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_ORDERDATE_ORDERFACT.setType(SQLSimpleTypes.Sql99.timestampType());
 
         COLUMN_PRICEEACH_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRICEEACH_ORDERFACT.setName("PRICEEACH");
-        COLUMN_PRICEEACH_ORDERFACT.setType(SqlSimpleTypes.numericType(18, 4));
+        COLUMN_PRICEEACH_ORDERFACT.setType(SQLSimpleTypes.numericType(18, 4));
 
         COLUMN_REQUIREDDATE_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_REQUIREDDATE_ORDERFACT.setName("REQUIREDDATE");
-        COLUMN_REQUIREDDATE_ORDERFACT.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_REQUIREDDATE_ORDERFACT.setType(SQLSimpleTypes.Sql99.timestampType());
 
         COLUMN_SHIPPEDDATE_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SHIPPEDDATE_ORDERFACT.setName("SHIPPEDDATE");
-        COLUMN_SHIPPEDDATE_ORDERFACT.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_SHIPPEDDATE_ORDERFACT.setType(SQLSimpleTypes.Sql99.timestampType());
 
         // Initialize Customer Table columns
         COLUMN_CUSTOMERNUMBER_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMERNUMBER_CUSTOMER.setName("CUSTOMERNUMBER");
-        COLUMN_CUSTOMERNUMBER_CUSTOMER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMERNUMBER_CUSTOMER.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_CUSTOMERNAME_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMERNAME_CUSTOMER.setName("CUSTOMERNAME");
-        COLUMN_CUSTOMERNAME_CUSTOMER.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_CUSTOMERNAME_CUSTOMER.setType(SQLSimpleTypes.varcharType(60));
 
         COLUMN_TERRITORY_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TERRITORY_CUSTOMER.setName("TERRITORY");
-        COLUMN_TERRITORY_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_TERRITORY_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_TERRITORY_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_COUNTRY_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COUNTRY_CUSTOMER.setName("COUNTRY");
-        COLUMN_COUNTRY_CUSTOMER.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_COUNTRY_CUSTOMER.setType(SQLSimpleTypes.varcharType(60));
         COLUMN_COUNTRY_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_STATE_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STATE_CUSTOMER.setName("STATE");
-        COLUMN_STATE_CUSTOMER.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_STATE_CUSTOMER.setType(SQLSimpleTypes.varcharType(60));
         COLUMN_STATE_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_CITY_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CITY_CUSTOMER.setName("CITY");
-        COLUMN_CITY_CUSTOMER.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_CITY_CUSTOMER.setType(SQLSimpleTypes.varcharType(60));
         COLUMN_CITY_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         COLUMN_CONTACTFIRSTNAME_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CONTACTFIRSTNAME_CUSTOMER.setName("CONTACTFIRSTNAME");
-        COLUMN_CONTACTFIRSTNAME_CUSTOMER.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_CONTACTFIRSTNAME_CUSTOMER.setType(SQLSimpleTypes.varcharType(60));
 
         COLUMN_CONTACTLASTNAME_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CONTACTLASTNAME_CUSTOMER.setName("CONTACTLASTNAME");
-        COLUMN_CONTACTLASTNAME_CUSTOMER.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_CONTACTLASTNAME_CUSTOMER.setType(SQLSimpleTypes.varcharType(60));
 
         COLUMN_PHONE_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PHONE_CUSTOMER.setName("PHONE");
-        COLUMN_PHONE_CUSTOMER.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_PHONE_CUSTOMER.setType(SQLSimpleTypes.varcharType(60));
 
         COLUMN_ADDRESSLINE1_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ADDRESSLINE1_CUSTOMER.setName("ADDRESSLINE1");
-        COLUMN_ADDRESSLINE1_CUSTOMER.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_ADDRESSLINE1_CUSTOMER.setType(SQLSimpleTypes.varcharType(60));
 
         COLUMN_CREDITLIMIT_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CREDITLIMIT_CUSTOMER.setName("CREDITLIMIT");
-        COLUMN_CREDITLIMIT_CUSTOMER.setType(SqlSimpleTypes.numericType(18, 4));
+        COLUMN_CREDITLIMIT_CUSTOMER.setType(SQLSimpleTypes.numericType(18, 4));
         COLUMN_CREDITLIMIT_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Initialize Products Table columns
         COLUMN_PRODUCTCODE_PRODUCTS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCTCODE_PRODUCTS.setName("PRODUCTCODE");
-        COLUMN_PRODUCTCODE_PRODUCTS.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_PRODUCTCODE_PRODUCTS.setType(SQLSimpleTypes.varcharType(60));
 
         COLUMN_PRODUCTNAME_PRODUCTS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCTNAME_PRODUCTS.setName("PRODUCTNAME");
-        COLUMN_PRODUCTNAME_PRODUCTS.setType(SqlSimpleTypes.varcharType(255));
+        COLUMN_PRODUCTNAME_PRODUCTS.setType(SQLSimpleTypes.varcharType(255));
 
         COLUMN_PRODUCTLINE_PRODUCTS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCTLINE_PRODUCTS.setName("PRODUCTLINE");
-        COLUMN_PRODUCTLINE_PRODUCTS.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_PRODUCTLINE_PRODUCTS.setType(SQLSimpleTypes.varcharType(60));
 
         COLUMN_PRODUCTVENDOR_PRODUCTS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCTVENDOR_PRODUCTS.setName("PRODUCTVENDOR");
-        COLUMN_PRODUCTVENDOR_PRODUCTS.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_PRODUCTVENDOR_PRODUCTS.setType(SQLSimpleTypes.varcharType(60));
 
         COLUMN_PRODUCTDESCRIPTION_PRODUCTS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCTDESCRIPTION_PRODUCTS.setName("PRODUCTDESCRIPTION");
-        COLUMN_PRODUCTDESCRIPTION_PRODUCTS.setType(SqlSimpleTypes.varcharType(1024));
+        COLUMN_PRODUCTDESCRIPTION_PRODUCTS.setType(SQLSimpleTypes.varcharType(1024));
 
         // Initialize Time Table columns
         COLUMN_TIME_ID_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_TIME_ID_TIME.setName("TIME_ID");
-        COLUMN_TIME_ID_TIME.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_TIME_ID_TIME.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_YEAR_ID_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_YEAR_ID_TIME.setName("YEAR_ID");
-        COLUMN_YEAR_ID_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_YEAR_ID_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_QTR_NAME_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_QTR_NAME_TIME.setName("QTR_NAME");
-        COLUMN_QTR_NAME_TIME.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_QTR_NAME_TIME.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_QTR_ID_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_QTR_ID_TIME.setName("QTR_ID");
-        COLUMN_QTR_ID_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_QTR_ID_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         COLUMN_MONTH_NAME_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MONTH_NAME_TIME.setName("MONTH_NAME");
-        COLUMN_MONTH_NAME_TIME.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_MONTH_NAME_TIME.setType(SQLSimpleTypes.varcharType(30));
 
         COLUMN_MONTH_ID_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MONTH_ID_TIME.setName("MONTH_ID");
-        COLUMN_MONTH_ID_TIME.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_MONTH_ID_TIME.setType(SQLSimpleTypes.Sql99.integerType());
 
         // Columns the mapping never reads but the CSVs carry: a table missing a
         // column its CSV has cannot be loaded.
         COLUMN_ORDERNUMBER_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ORDERNUMBER_ORDERFACT.setName("ORDERNUMBER");
-        COLUMN_ORDERNUMBER_ORDERFACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ORDERNUMBER_ORDERFACT.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_ORDERNUMBER_ORDERFACT.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_ORDERLINENUMBER_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ORDERLINENUMBER_ORDERFACT.setName("ORDERLINENUMBER");
-        COLUMN_ORDERLINENUMBER_ORDERFACT.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ORDERLINENUMBER_ORDERFACT.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_ORDERLINENUMBER_ORDERFACT.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_COMMENTS_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COMMENTS_ORDERFACT.setName("COMMENTS");
-        COLUMN_COMMENTS_ORDERFACT.setType(SqlSimpleTypes.varcharType(1024));
+        COLUMN_COMMENTS_ORDERFACT.setType(SQLSimpleTypes.varcharType(1024));
         COLUMN_COMMENTS_ORDERFACT.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_QTR_ID_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_QTR_ID_ORDERFACT.setName("QTR_ID");
-        COLUMN_QTR_ID_ORDERFACT.setType(SqlSimpleTypes.bigintType());
+        COLUMN_QTR_ID_ORDERFACT.setType(SQLSimpleTypes.bigintType());
         COLUMN_QTR_ID_ORDERFACT.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_MONTH_ID_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MONTH_ID_ORDERFACT.setName("MONTH_ID");
-        COLUMN_MONTH_ID_ORDERFACT.setType(SqlSimpleTypes.bigintType());
+        COLUMN_MONTH_ID_ORDERFACT.setType(SQLSimpleTypes.bigintType());
         COLUMN_MONTH_ID_ORDERFACT.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_YEAR_ID_ORDERFACT = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_YEAR_ID_ORDERFACT.setName("YEAR_ID");
-        COLUMN_YEAR_ID_ORDERFACT.setType(SqlSimpleTypes.bigintType());
+        COLUMN_YEAR_ID_ORDERFACT.setType(SQLSimpleTypes.bigintType());
         COLUMN_YEAR_ID_ORDERFACT.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_ADDRESSLINE2_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ADDRESSLINE2_CUSTOMER.setName("ADDRESSLINE2");
-        COLUMN_ADDRESSLINE2_CUSTOMER.setType(SqlSimpleTypes.varcharType(60));
+        COLUMN_ADDRESSLINE2_CUSTOMER.setType(SQLSimpleTypes.varcharType(60));
         COLUMN_ADDRESSLINE2_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_POSTALCODE_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_POSTALCODE_CUSTOMER.setName("POSTALCODE");
-        COLUMN_POSTALCODE_CUSTOMER.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_POSTALCODE_CUSTOMER.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_POSTALCODE_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_EMPLOYEENUMBER_CUSTOMER = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_EMPLOYEENUMBER_CUSTOMER.setName("EMPLOYEENUMBER");
-        COLUMN_EMPLOYEENUMBER_CUSTOMER.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_EMPLOYEENUMBER_CUSTOMER.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_EMPLOYEENUMBER_CUSTOMER.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_PRODUCTSCALE_PRODUCTS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_PRODUCTSCALE_PRODUCTS.setName("PRODUCTSCALE");
-        COLUMN_PRODUCTSCALE_PRODUCTS.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_PRODUCTSCALE_PRODUCTS.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_QUANTITYINSTOCK_PRODUCTS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_QUANTITYINSTOCK_PRODUCTS.setName("QUANTITYINSTOCK");
-        COLUMN_QUANTITYINSTOCK_PRODUCTS.setType(SqlSimpleTypes.Sql99.smallintType());
+        COLUMN_QUANTITYINSTOCK_PRODUCTS.setType(SQLSimpleTypes.Sql99.smallintType());
         COLUMN_BUYPRICE_PRODUCTS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_BUYPRICE_PRODUCTS.setName("BUYPRICE");
-        COLUMN_BUYPRICE_PRODUCTS.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_BUYPRICE_PRODUCTS.setType(SQLSimpleTypes.decimalType(10, 4));
         COLUMN_MSRP_PRODUCTS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MSRP_PRODUCTS.setName("MSRP");
-        COLUMN_MSRP_PRODUCTS.setType(SqlSimpleTypes.decimalType(10, 4));
+        COLUMN_MSRP_PRODUCTS.setType(SQLSimpleTypes.decimalType(10, 4));
         COLUMN_MONTH_DESC_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_MONTH_DESC_TIME.setName("MONTH_DESC");
-        COLUMN_MONTH_DESC_TIME.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_MONTH_DESC_TIME.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_MONTH_DESC_TIME.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_QTR_DESC_TIME = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_QTR_DESC_TIME.setName("QTR_DESC");
-        COLUMN_QTR_DESC_TIME.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_QTR_DESC_TIME.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_QTR_DESC_TIME.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // orders is outside the star, but a test cube is built on it.
         COLUMN_ORDERNUMBER_ORDERS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ORDERNUMBER_ORDERS.setName("ORDERNUMBER");
-        COLUMN_ORDERNUMBER_ORDERS.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_ORDERNUMBER_ORDERS.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_ORDERDATE_ORDERS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_ORDERDATE_ORDERS.setName("ORDERDATE");
-        COLUMN_ORDERDATE_ORDERS.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_ORDERDATE_ORDERS.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_ORDERDATE_ORDERS.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_REQUIREDDATE_ORDERS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_REQUIREDDATE_ORDERS.setName("REQUIREDDATE");
-        COLUMN_REQUIREDDATE_ORDERS.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_REQUIREDDATE_ORDERS.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_REQUIREDDATE_ORDERS.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_SHIPPEDDATE_ORDERS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_SHIPPEDDATE_ORDERS.setName("SHIPPEDDATE");
-        COLUMN_SHIPPEDDATE_ORDERS.setType(SqlSimpleTypes.Sql99.timestampType());
+        COLUMN_SHIPPEDDATE_ORDERS.setType(SQLSimpleTypes.Sql99.timestampType());
         COLUMN_SHIPPEDDATE_ORDERS.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_STATUS_ORDERS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_STATUS_ORDERS.setName("STATUS");
-        COLUMN_STATUS_ORDERS.setType(SqlSimpleTypes.varcharType(30));
+        COLUMN_STATUS_ORDERS.setType(SQLSimpleTypes.varcharType(30));
         COLUMN_COMMENTS_ORDERS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_COMMENTS_ORDERS.setName("COMMENTS");
-        COLUMN_COMMENTS_ORDERS.setType(SqlSimpleTypes.varcharType(1024));
+        COLUMN_COMMENTS_ORDERS.setType(SQLSimpleTypes.varcharType(1024));
         COLUMN_COMMENTS_ORDERS.setIsNullable(NullableType.COLUMN_NULLABLE);
         COLUMN_CUSTOMERNUMBER_ORDERS = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         COLUMN_CUSTOMERNUMBER_ORDERS.setName("CUSTOMERNUMBER");
-        COLUMN_CUSTOMERNUMBER_ORDERS.setType(SqlSimpleTypes.Sql99.integerType());
+        COLUMN_CUSTOMERNUMBER_ORDERS.setType(SQLSimpleTypes.Sql99.integerType());
         COLUMN_CUSTOMERNUMBER_ORDERS.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         // Initialize tables

--- a/instance/emf/serializer/src/test/java/org/eclipse/daanse/rolap/mapping/instance/emf/serializer/integration/ResourceSetWriteReadTest.java
+++ b/instance/emf/serializer/src/test/java/org/eclipse/daanse/rolap/mapping/instance/emf/serializer/integration/ResourceSetWriteReadTest.java
@@ -94,7 +94,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.Hierarchy
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelPackage;
 import org.eclipse.daanse.rolap.mapping.model.olap.format.FormatPackage;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionPackage;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLDataType;
 @ExtendWith(BundleContextExtension.class)
 @ExtendWith(ServiceExtension.class)
@@ -272,7 +272,7 @@ public class ResourceSetWriteReadTest {
 
         // Deduplicate SQLSimpleType instances with identical semantics (same
         // name + length + precision + scale). CatalogSupplier code calls
-        // SqlSimpleTypes.Sql99.varcharType() once per column, so many freshly-built
+        // SQLSimpleTypes.Sql99.varcharType() once per column, so many freshly-built
         // instances describe e.g. VARCHAR(255) redundantly. Collapse them to a
         // single shared instance per catalog before serialization.
         sortedList = deduplicateSqlTypes(sortedList);
@@ -620,7 +620,7 @@ public class ResourceSetWriteReadTest {
     private static String jdbcTypeToken(EObject column) {
         EStructuralFeature typeFeat = column.eClass().getEStructuralFeature("type");
         if (typeFeat != null && column.eGet(typeFeat) instanceof SQLDataType sdt) {
-            JDBCType jt = SqlSimpleTypes.toJdbcType(sdt);
+            JDBCType jt = SQLSimpleTypes.toJdbcType(sdt);
             if (jt != null && jt != JDBCType.OTHER) {
                 return jt.getName();
             }

--- a/instance/emf/tck/hierarchy/levelswithsamenames/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tck/hierarchy/levelswithsamenames/CatalogSupplier.java
+++ b/instance/emf/tck/hierarchy/levelswithsamenames/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tck/hierarchy/levelswithsamenames/CatalogSupplier.java
@@ -18,7 +18,7 @@ import java.util.List;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.rolap.mapping.instance.api.TutorialDescriptionSupplier;
 import org.eclipse.daanse.rolap.mapping.model.catalog.Catalog;
 import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
@@ -72,15 +72,15 @@ public class CatalogSupplier implements CatalogMappingSupplier {
 
         Column yearColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         yearColumn.setName("YEAR");
-        yearColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        yearColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column idColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         idColumn.setName("ID");
-        idColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        idColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");
@@ -89,23 +89,23 @@ public class CatalogSupplier implements CatalogMappingSupplier {
 
         Column idColumnTown = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         idColumnTown.setName("ID");
-        idColumnTown.setType(SqlSimpleTypes.Sql99.integerType());
+        idColumnTown.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column townIdColumnTown = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         townIdColumnTown.setName("TOWNID");
-        townIdColumnTown.setType(SqlSimpleTypes.Sql99.integerType());
+        townIdColumnTown.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column nameColumnTown = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         nameColumnTown.setName("NAME");
-        nameColumnTown.setType(SqlSimpleTypes.Sql99.varcharType());
+        nameColumnTown.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column objectIdColumnTown = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         objectIdColumnTown.setName("OBJECTID");
-        objectIdColumnTown.setType(SqlSimpleTypes.Sql99.integerType());
+        objectIdColumnTown.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column objectColumnTown = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         objectColumnTown.setName("OBJECT");
-        objectColumnTown.setType(SqlSimpleTypes.Sql99.varcharType());
+        objectColumnTown.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableTown = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableTown.setName("Town");

--- a/instance/emf/tutorial/access/cataloggrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/cataloggrand/CatalogSupplier.java
+++ b/instance/emf/tutorial/access/cataloggrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/cataloggrand/CatalogSupplier.java
@@ -55,7 +55,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.04.04", source = Source.EMF, group = "Access") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -131,11 +131,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/access/columngrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/columngrand/CatalogSupplier.java
+++ b/instance/emf/tutorial/access/columngrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/columngrand/CatalogSupplier.java
@@ -52,7 +52,7 @@ import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.04.03", source = Source.EMF, group = "Access") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -101,11 +101,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/access/cubegrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/cubegrand/CatalogSupplier.java
+++ b/instance/emf/tutorial/access/cubegrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/cubegrand/CatalogSupplier.java
@@ -55,7 +55,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.04.05", source = Source.EMF, group = "Access") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -120,11 +120,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/access/databaseschemagrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/databaseschemagrand/CatalogSupplier.java
+++ b/instance/emf/tutorial/access/databaseschemagrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/databaseschemagrand/CatalogSupplier.java
@@ -48,7 +48,7 @@ import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.04.01", source = Source.EMF, group = "Access") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -97,11 +97,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/access/defaultrole/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/defaultrole/CatalogSupplier.java
+++ b/instance/emf/tutorial/access/defaultrole/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/defaultrole/CatalogSupplier.java
@@ -59,7 +59,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.04.07", source = Source.EMF, group = "Access") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -129,11 +129,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/access/dimensiongrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/dimensiongrand/CatalogSupplier.java
+++ b/instance/emf/tutorial/access/dimensiongrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/dimensiongrand/CatalogSupplier.java
@@ -58,7 +58,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.04.06", source = Source.EMF, group = "Access") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -120,11 +120,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/access/hierarchygrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/hierarchygrand/CatalogSupplier.java
+++ b/instance/emf/tutorial/access/hierarchygrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/hierarchygrand/CatalogSupplier.java
@@ -59,7 +59,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.04.07", source = Source.EMF, group = "Access") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -122,11 +122,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/access/membergrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/membergrand/CatalogSupplier.java
+++ b/instance/emf/tutorial/access/membergrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/membergrand/CatalogSupplier.java
@@ -62,7 +62,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.04.08", source = Source.EMF, group = "Access") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -134,11 +134,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/access/tablegrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/tablegrand/CatalogSupplier.java
+++ b/instance/emf/tutorial/access/tablegrand/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/access/tablegrand/CatalogSupplier.java
@@ -50,7 +50,7 @@ import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.04.02", source = Source.EMF, group = "Access") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -105,11 +105,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/action/drillthrough/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/action/drillthrough/CatalogSupplier.java
+++ b/instance/emf/tutorial/action/drillthrough/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/action/drillthrough/CatalogSupplier.java
@@ -50,7 +50,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.10.01", source = Source.EMF, group = "Actions") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -174,11 +174,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);
@@ -190,11 +190,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column h1L1KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         h1L1KeyColumn.setName("KEY");
-        h1L1KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        h1L1KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column h1L1NameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         h1L1NameColumn.setName("NAME");
-        h1L1NameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        h1L1NameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table h1L1table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         h1L1table.setName("H1_L1");
@@ -203,11 +203,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column h2L1KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         h2L1KeyColumn.setName("KEY");
-        h2L1KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        h2L1KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column h2L1NameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         h2L1NameColumn.setName("NAME");
-        h2L1NameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        h2L1NameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table h2L1table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         h2L1table.setName("H2_L1");
@@ -216,19 +216,19 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column hxL2KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         hxL2KeyColumn.setName("KEY");
-        hxL2KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        hxL2KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column hxL2NameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         hxL2NameColumn.setName("NAME");
-        hxL2NameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        hxL2NameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column hxL2H1L1KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         hxL2H1L1KeyColumn.setName("H1L1_KEY");
-        hxL2H1L1KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        hxL2H1L1KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column hxL2H2L1KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         hxL2H2L1KeyColumn.setName("H2L1_KEY");
-        hxL2H2L1KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        hxL2H2L1KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table hxL2table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         hxL2table.setName("HX_L2");

--- a/instance/emf/tutorial/aggregation/aggexclude/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/aggregation/aggexclude/CatalogSupplier.java
+++ b/instance/emf/tutorial/aggregation/aggexclude/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/aggregation/aggexclude/CatalogSupplier.java
@@ -40,7 +40,7 @@ import org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationFa
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.08.01", source = Source.EMF, group = "Aggregation") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -84,11 +84,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);
@@ -100,11 +100,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column aggKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         aggKeyColumn.setName("KEY");
-        aggKeyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        aggKeyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column aggValueCountColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         aggValueCountColumn.setName("VALUE_count");
-        aggValueCountColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        aggValueCountColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table aggTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         aggTable.setName("agg_01_Fact");

--- a/instance/emf/tutorial/aggregation/aggregatetables/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/aggregation/aggregatetables/CatalogSupplier.java
+++ b/instance/emf/tutorial/aggregation/aggregatetables/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/aggregation/aggregatetables/CatalogSupplier.java
@@ -53,7 +53,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.08.02", source = Source.EMF, group = "Aggregation") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -142,11 +142,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column productIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         productIdColumn.setName("PRODUCT_ID");
-        productIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        productIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column storeCostColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         storeCostColumn.setName("STORE_COST");
-        storeCostColumn.setType(SqlSimpleTypes.decimalType(18, 4));
+        storeCostColumn.setType(SQLSimpleTypes.decimalType(18, 4));
 
         Table salesFact1997 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         salesFact1997.setName(SALES_FACT_1997);
@@ -155,19 +155,19 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column productProductClassIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         productProductClassIdColumn.setName("PRODUCT_CLASS_ID");
-        productProductClassIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        productProductClassIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column productProductIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         productProductIdColumn.setName("PRODUCT_ID");
-        productProductIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        productProductIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column productBrandNameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         productBrandNameColumn.setName("brand_name");
-        productBrandNameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        productBrandNameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column productProductNameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         productProductNameColumn.setName("product_name");
-        productProductNameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        productProductNameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table productTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         productTable.setName("PRODUCT");
@@ -177,11 +177,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column productClassProductClassIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         productClassProductClassIdColumn.setName("PRODUCT_CLASS_ID");
-        productClassProductClassIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        productClassProductClassIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column productClassProductFamileColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         productClassProductFamileColumn.setName("PRODUCT_FAMILE");
-        productClassProductFamileColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        productClassProductFamileColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table productClassTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         productClassTable.setName("PRODUCT_CLASS");
@@ -191,15 +191,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column aggCSpecialSalesFact1997ProductIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         aggCSpecialSalesFact1997ProductIdColumn.setName("PRODUCT_ID");
-        aggCSpecialSalesFact1997ProductIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        aggCSpecialSalesFact1997ProductIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column aggCSpecialSalesFact1997StoreCostSumColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         aggCSpecialSalesFact1997StoreCostSumColumn.setName("STORE_COST_SUM");
-        aggCSpecialSalesFact1997StoreCostSumColumn.setType(SqlSimpleTypes.decimalType(18, 4));
+        aggCSpecialSalesFact1997StoreCostSumColumn.setType(SQLSimpleTypes.decimalType(18, 4));
 
         Column aggCSpecialSalesFact1997FactCountColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         aggCSpecialSalesFact1997FactCountColumn.setName("FACT_COUNT");
-        aggCSpecialSalesFact1997FactCountColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        aggCSpecialSalesFact1997FactCountColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         //PRODUCT_ID,STORE_COST_SUM,FACT_COUNT
         //INTEGER,DECIMAL(10.4),INTEGER

--- a/instance/emf/tutorial/cube/calculatedmember.color/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/calculatedmember/color/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/calculatedmember.color/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/calculatedmember/color/CatalogSupplier.java
@@ -48,7 +48,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.03.06", source = Source.EMF, group = "Cube") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -101,11 +101,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/calculatedmember.intro/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/calculatedmember/intro/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/calculatedmember.intro/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/calculatedmember/intro/CatalogSupplier.java
@@ -47,7 +47,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.03.06", source = Source.EMF, group = "Member") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -100,11 +100,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/calculatedmember.property/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/calculatedmember/property/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/calculatedmember.property/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/calculatedmember/property/CatalogSupplier.java
@@ -48,7 +48,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.03.06", source = Source.EMF, group = "Cube") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -101,11 +101,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/dimension.intro/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/dimension/intro/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/dimension.intro/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/dimension/intro/CatalogSupplier.java
@@ -45,7 +45,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.03.01", source = Source.EMF, group = "Dimension")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -101,11 +101,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/hierarchy.hasall/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/hierarchy/hasall/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/hierarchy.hasall/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/hierarchy/hasall/CatalogSupplier.java
@@ -45,7 +45,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.03.04", source = Source.EMF, group = "Hierarchy") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -117,11 +117,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/hierarchy.query.join.base/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/hierarchy/query/join/base/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/hierarchy.query.join.base/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/hierarchy/query/join/base/CatalogSupplier.java
@@ -47,7 +47,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.03.03.01", source = Source.EMF, group = "Hierarchy")//NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -133,11 +133,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column townIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         townIdColumn.setName("TOWN_ID");
-        townIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        townIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");
@@ -146,15 +146,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyTownColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyTownColumn.setName("ID");
-        keyTownColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        keyTownColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column nameTownColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         nameTownColumn.setName("NAME");
-        nameTownColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        nameTownColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column idTownCountryIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         idTownCountryIdColumn.setName("COUNTRY_ID");
-        idTownCountryIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        idTownCountryIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table tableTown = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableTown.setName("Town");
@@ -163,11 +163,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyCountryColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyCountryColumn.setName("ID");
-        keyCountryColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        keyCountryColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column nameCountryColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         nameCountryColumn.setName("NAME");
-        nameCountryColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        nameCountryColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableCountry = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableCountry.setName("Country");

--- a/instance/emf/tutorial/cube/hierarchy.query.join.multi/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/hierarchy/query/join/multi/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/hierarchy.query.join.multi/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/hierarchy/query/join/multi/CatalogSupplier.java
@@ -47,7 +47,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.03.03.02", source = Source.EMF, group = "Hierarchy") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -159,11 +159,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column townIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         townIdColumn.setName("TOWN_ID");
-        townIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        townIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");
@@ -172,15 +172,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnTownId = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTownId.setName("ID");
-        columnTownId.setType(SqlSimpleTypes.Sql99.integerType());
+        columnTownId.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnTownName = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTownName.setName("NAME");
-        columnTownName.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnTownName.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnTownCountryId = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTownCountryId.setName("COUNTRY_ID");
-        columnTownCountryId.setType(SqlSimpleTypes.Sql99.integerType());
+        columnTownCountryId.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table tableTown = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableTown.setName("Town");
@@ -189,15 +189,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnCountryId = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnCountryId.setName("ID");
-        columnCountryId.setType(SqlSimpleTypes.Sql99.integerType());
+        columnCountryId.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnCountryName = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnCountryName.setName("NAME");
-        columnCountryName.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnCountryName.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnCountryContinentId = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnCountryContinentId.setName("CONTINENT_ID");
-        columnCountryContinentId.setType(SqlSimpleTypes.Sql99.integerType());
+        columnCountryContinentId.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table tableCountry = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableCountry.setName("Country");
@@ -206,11 +206,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnContinentId = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnContinentId.setName("ID");
-        columnContinentId.setType(SqlSimpleTypes.Sql99.integerType());
+        columnContinentId.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnContinentName = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnContinentName.setName("NAME");
-        columnContinentName.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnContinentName.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableContinent = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableContinent.setName("Continent");

--- a/instance/emf/tutorial/cube/hierarchy.query.table.base/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/hierarchy/query/table/base/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/hierarchy.query.table.base/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/hierarchy/query/table/base/CatalogSupplier.java
@@ -45,7 +45,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.03.02.01", source = Source.EMF, group = "Hierarchy") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -100,11 +100,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnFactTownId = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnFactTownId.setName("TOWN_ID");
-        columnFactTownId.setType(SqlSimpleTypes.Sql99.integerType());
+        columnFactTownId.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnFactValue = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnFactValue.setName("VALUE");
-        columnFactValue.setType(SqlSimpleTypes.Sql99.integerType());
+        columnFactValue.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table tableFact = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableFact.setName("Fact");
@@ -113,11 +113,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnTownId = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTownId.setName("ID");
-        columnTownId.setType(SqlSimpleTypes.Sql99.integerType());
+        columnTownId.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnTownName = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTownName.setName("NAME");
-        columnTownName.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnTownName.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableTown = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableTown.setName("Town");

--- a/instance/emf/tutorial/cube/hierarchy.query.table.multilevel.multitable/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/hierarchy/query/table/multilevel/multitable/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/hierarchy.query.table.multilevel.multitable/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/hierarchy/query/table/multilevel/multitable/CatalogSupplier.java
@@ -45,7 +45,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.03.02.02", source = Source.EMF, group = "Hierarchy")//NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -122,11 +122,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column townIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         townIdColumn.setName("TOWN_ID");
-        townIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        townIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");
@@ -135,15 +135,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumnTown = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumnTown.setName("ID");
-        keyColumnTown.setType(SqlSimpleTypes.Sql99.integerType());
+        keyColumnTown.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column nameColumnTown = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         nameColumnTown.setName("NAME");
-        nameColumnTown.setType(SqlSimpleTypes.Sql99.varcharType());
+        nameColumnTown.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column keyColumnCountry = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumnCountry.setName("COUNTRY");
-        keyColumnCountry.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumnCountry.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableTown = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableTown.setName("Town");

--- a/instance/emf/tutorial/cube/hierarchy.query.table.multilevel.singletable/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/hierarchy/query/table/multilevel/singletable/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/hierarchy.query.table.multilevel.singletable/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/hierarchy/query/table/multilevel/singletable/CatalogSupplier.java
@@ -45,7 +45,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.03.02.03", source = Source.EMF, group = "Hierarchy") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -102,15 +102,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnKey = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnKey.setName("KEY");
-        columnKey.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnKey.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnValue = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnValue.setName("VALUE");
-        columnValue.setType(SqlSimpleTypes.Sql99.integerType());
+        columnValue.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnCountry = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnCountry.setName("COUNTRY");
-        columnCountry.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnCountry.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableFact = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableFact.setName("Fact");

--- a/instance/emf/tutorial/cube/measure.aggregator.base/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/aggregator/base/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/measure.aggregator.base/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/aggregator/base/CatalogSupplier.java
@@ -41,7 +41,7 @@ import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.02.01", source = Source.EMF, group = "Measure")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -77,11 +77,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/measure.aggregator.bit/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/aggregator/bit/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/measure.aggregator.bit/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/aggregator/bit/CatalogSupplier.java
@@ -39,7 +39,7 @@ import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.02.06", source = Source.EMF, group = "Measure")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -77,11 +77,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/measure.aggregator.nth/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/aggregator/nth/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/measure.aggregator.nth/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/aggregator/nth/CatalogSupplier.java
@@ -47,7 +47,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.02.07", source = Source.EMF, group = "Measure")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -93,15 +93,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column idColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         idColumn.setName("ID");
-        idColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        idColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column nameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         nameColumn.setName("NAME");
-        nameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        nameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/measure.aggregator.percentile/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/aggregator/percentile/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/measure.aggregator.percentile/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/aggregator/percentile/CatalogSupplier.java
@@ -48,7 +48,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.02.07", source = Source.EMF, group = "Measure")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -97,11 +97,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/measure.aggregator.textagg/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/aggregator/textagg/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/measure.aggregator.textagg/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/aggregator/textagg/CatalogSupplier.java
@@ -52,7 +52,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.02.08", source = Source.EMF, group = "Measure")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -93,39 +93,39 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnCountry = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnCountry.setName("COUNTRY");
-        columnCountry.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnCountry.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnContinent = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnContinent.setName("CONTINENT");
-        columnContinent.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnContinent.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnYear = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnYear.setName("YEAR");
-        columnYear.setType(SqlSimpleTypes.Sql99.integerType());
+        columnYear.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnMonth = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnMonth.setName("MONTH");
-        columnMonth.setType(SqlSimpleTypes.Sql99.integerType());
+        columnMonth.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnMonthName = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnMonthName.setName("MONTH_NAME");
-        columnMonthName.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnMonthName.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnUser = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnUser.setName("USER");
-        columnUser.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnUser.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnComment = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnComment.setName("COMMENT");
-        columnComment.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnComment.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/measure.datatype/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/datatype/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/measure.datatype/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/datatype/CatalogSupplier.java
@@ -39,7 +39,7 @@ import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.02.03", source = Source.EMF, group = "Measure")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -87,11 +87,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/measure.format/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/format/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/measure.format/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/format/CatalogSupplier.java
@@ -38,7 +38,7 @@ import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.02.04", source = Source.EMF, group = "Measure")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -107,11 +107,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/measure.group/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/group/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/measure.group/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/group/CatalogSupplier.java
@@ -38,7 +38,7 @@ import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.02.05", source = Source.EMF, group = "Measure")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -71,11 +71,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/measure.multiple/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/multiple/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/measure.multiple/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/measure/multiple/CatalogSupplier.java
@@ -38,7 +38,7 @@ import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.02.02", source = Source.EMF, group = "Measure")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -79,19 +79,19 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column value1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         value1Column.setName("VALUE1");
-        value1Column.setType(SqlSimpleTypes.Sql99.integerType());
+        value1Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column value2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         value2Column.setName("VALUE2");
-        value2Column.setType(SqlSimpleTypes.Sql99.integerType());
+        value2Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column value3Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         value3Column.setName("VALUE3");
-        value3Column.setType(SqlSimpleTypes.Sql99.integerType());
+        value3Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/minimal/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/minimal/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/minimal/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/minimal/CatalogSupplier.java
@@ -38,7 +38,7 @@ import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.01.01", source = Source.EMF, group = "Cube")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -75,11 +75,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/cube/sqlview/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/sqlview/CatalogSupplier.java
+++ b/instance/emf/tutorial/cube/sqlview/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/cube/sqlview/CatalogSupplier.java
@@ -39,7 +39,7 @@ import org.eclipse.daanse.rolap.mapping.instance.api.TutorialDescriptionSupplier
 import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.01.02", source = Source.EMF, group = "Cube")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -71,11 +71,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnKeyFact = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnKeyFact.setName("KEY");
-        columnKeyFact.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnKeyFact.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnValueFact = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnValueFact.setName("VALUE");
-        columnValueFact.setType(SqlSimpleTypes.Sql99.integerType());
+        columnValueFact.setType(SQLSimpleTypes.Sql99.integerType());
 
         table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("FACT");
@@ -84,11 +84,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnKey = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnKey.setName("Key");
-        columnKey.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnKey.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnValue = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnValue.setName("Value");
-        columnValue.setType(SqlSimpleTypes.Sql99.integerType());
+        columnValue.setType(SQLSimpleTypes.Sql99.integerType());
 
         sqlview = org.eclipse.daanse.rolap.mapping.model.database.relational.RelationalFactory.eINSTANCE.createDialectSqlView();
         sqlview.setName("sqlview");

--- a/instance/emf/tutorial/database/column/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/column/CatalogSupplier.java
+++ b/instance/emf/tutorial/database/column/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/column/CatalogSupplier.java
@@ -31,7 +31,7 @@ import org.eclipse.daanse.rolap.mapping.instance.api.TutorialDescription;
 import org.eclipse.daanse.rolap.mapping.instance.api.TutorialDescriptionSupplier;
 
 import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "1.02.01", source = Source.EMF, group = "Database")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -93,35 +93,35 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         columnCommon = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnCommon.setName("ColumnWithDescription");
-        columnCommon.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnCommon.setType(SQLSimpleTypes.Sql99.varcharType());
 
         columnVarchar = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnVarchar.setName("ColumnVarchar");
-        columnVarchar.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnVarchar.setType(SQLSimpleTypes.Sql99.varcharType());
 
         columnDecimal = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnDecimal.setName("ColumnDecimal");
-        columnDecimal.setType(SqlSimpleTypes.decimalType(18, 4));
+        columnDecimal.setType(SQLSimpleTypes.decimalType(18, 4));
 
         columnNumeric = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnNumeric.setName("ColumnNumeric");
-        columnNumeric.setType(SqlSimpleTypes.numericType(18, 4));
+        columnNumeric.setType(SQLSimpleTypes.numericType(18, 4));
 
         columnFloat = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnFloat.setName("ColumnFloat");
-        columnFloat.setType(SqlSimpleTypes.Sql99.floatType());
+        columnFloat.setType(SQLSimpleTypes.Sql99.floatType());
 
         columnReal = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnReal.setName("ColumnReal");
-        columnReal.setType(SqlSimpleTypes.Sql99.realType());
+        columnReal.setType(SQLSimpleTypes.Sql99.realType());
 
         columnDouble = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnDouble.setName("ColumnDouble");
-        columnDouble.setType(SqlSimpleTypes.Sql99.doublePrecisionType());
+        columnDouble.setType(SQLSimpleTypes.Sql99.doublePrecisionType());
 
         columnInteger = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnInteger.setName("ColumnInteger");
-        columnInteger.setType(SqlSimpleTypes.Sql99.integerType());
+        columnInteger.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("TableWithColumnTypes");

--- a/instance/emf/tutorial/database/expressioncolumn/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/expressioncolumn/CatalogSupplier.java
+++ b/instance/emf/tutorial/database/expressioncolumn/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/expressioncolumn/CatalogSupplier.java
@@ -23,7 +23,7 @@ import org.eclipse.daanse.rolap.mapping.model.catalog.Catalog;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.rolap.mapping.model.RolapMappingFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.relational.ExpressionColumn;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement;
@@ -60,7 +60,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         column.setName("column1");
-        column.setType(SqlSimpleTypes.Sql99.varcharType());
+        column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         SqlStatement sqlStatement1 = SourceFactory.eINSTANCE.createSqlStatement();
         sqlStatement1.setSql("SUBSTRING(column1,1,3)");

--- a/instance/emf/tutorial/database/inlinetable/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/inlinetable/CatalogSupplier.java
+++ b/instance/emf/tutorial/database/inlinetable/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/inlinetable/CatalogSupplier.java
@@ -36,7 +36,7 @@ import org.eclipse.daanse.rolap.mapping.instance.api.TutorialDescription;
 import org.eclipse.daanse.rolap.mapping.instance.api.TutorialDescriptionSupplier;
 
 import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "1.03.03", source = Source.EMF, group = "Database")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -60,11 +60,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         DataSlot rowValue1 = InstanceFactory.eINSTANCE.createDataSlot();
         rowValue1.setFeature(keyColumn);

--- a/instance/emf/tutorial/database/intro/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/intro/CatalogSupplier.java
+++ b/instance/emf/tutorial/database/intro/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/intro/CatalogSupplier.java
@@ -25,7 +25,7 @@ import org.eclipse.daanse.rolap.mapping.instance.api.TutorialDescriptionSupplier
 import org.eclipse.daanse.rolap.mapping.model.catalog.Catalog;
 import org.eclipse.daanse.rolap.mapping.model.RolapMappingFactory;
 import org.eclipse.daanse.rolap.mapping.model.provider.CatalogMappingSupplier;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.osgi.service.component.annotations.Component;
 
 import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
@@ -75,7 +75,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         columnOne = RelationalFactory.eINSTANCE.createColumn();
         columnOne.setName("ColumnOne");
-        columnOne.setType(SqlSimpleTypes.varcharType(255));
+        columnOne.setType(SQLSimpleTypes.varcharType(255));
 
         tableOne = RelationalFactory.eINSTANCE.createTable();
         tableOne.setName("TableOne");

--- a/instance/emf/tutorial/database/schema/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/schema/CatalogSupplier.java
+++ b/instance/emf/tutorial/database/schema/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/schema/CatalogSupplier.java
@@ -31,7 +31,7 @@ import org.eclipse.daanse.rolap.mapping.instance.api.TutorialDescription;
 import org.eclipse.daanse.rolap.mapping.instance.api.TutorialDescriptionSupplier;
 
 import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "1.03", source = Source.EMF, group = "Database")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -64,7 +64,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnOther = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnOther.setName("theColumn");
-        columnOther.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnOther.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableOther = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableOther.setName("theTable");
@@ -75,7 +75,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnDefault = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnDefault.setName("theColumn");
-        columnDefault.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnDefault.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableDefault = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableDefault.setName("theTable");

--- a/instance/emf/tutorial/database/sqlview/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/sqlview/CatalogSupplier.java
+++ b/instance/emf/tutorial/database/sqlview/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/sqlview/CatalogSupplier.java
@@ -33,7 +33,7 @@ import org.eclipse.daanse.rolap.mapping.instance.api.TutorialDescriptionSupplier
 
 import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "1.03.02", source = Source.EMF, group = "Database")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -56,7 +56,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         column.setName("ColumnOne");
-        column.setType(SqlSimpleTypes.Sql99.varcharType());
+        column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         sqlview = org.eclipse.daanse.rolap.mapping.model.database.relational.RelationalFactory.eINSTANCE.createDialectSqlView();
         sqlview.setName("sqlview");

--- a/instance/emf/tutorial/database/table/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/table/CatalogSupplier.java
+++ b/instance/emf/tutorial/database/table/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/database/table/CatalogSupplier.java
@@ -33,7 +33,7 @@ import org.eclipse.daanse.rolap.mapping.instance.api.TutorialDescription;
 import org.eclipse.daanse.rolap.mapping.instance.api.TutorialDescriptionSupplier;
 
 import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "1.03.01", source = Source.EMF, group = "Database")
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -66,7 +66,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         column.setName("ColumnOne");
-        column.setType(SqlSimpleTypes.Sql99.varcharType());
+        column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("TableOne");
@@ -75,7 +75,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column column2 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         column2.setName("ColumnOne");
-        column2.setType(SqlSimpleTypes.Sql99.varcharType());
+        column2.setType(SQLSimpleTypes.Sql99.varcharType());
 
         table2 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createView();
         table2.setName("ViewOne");
@@ -84,7 +84,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column column3 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         column3.setName("ColumnOne");
-        column3.setType(SqlSimpleTypes.Sql99.varcharType());
+        column3.setType(SQLSimpleTypes.Sql99.varcharType());
 
         table3 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table3.setName("TableOne");

--- a/instance/emf/tutorial/dimension/optimisationwithlevelattribute/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/dimension/optimisationwithlevelattribute/CatalogSupplier.java
+++ b/instance/emf/tutorial/dimension/optimisationwithlevelattribute/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/dimension/optimisationwithlevelattribute/CatalogSupplier.java
@@ -47,7 +47,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.09.02", source = Source.EMF, group = "Dimension") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -135,11 +135,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column dimKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         dimKeyColumn.setName("DIM_KEY");
-        dimKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        dimKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);
@@ -148,11 +148,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column h1L1KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         h1L1KeyColumn.setName("KEY");
-        h1L1KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        h1L1KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column h1L1NameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         h1L1NameColumn.setName("NAME");
-        h1L1NameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        h1L1NameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table h1L1Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         h1L1Table.setName("H1_L1");
@@ -161,19 +161,19 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column hxL2KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         hxL2KeyColumn.setName("KEY");
-        hxL2KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        hxL2KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column hxL2NameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         hxL2NameColumn.setName("NAME");
-        hxL2NameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        hxL2NameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column hxL2H1L1KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         hxL2H1L1KeyColumn.setName("H1L1_KEY");
-        hxL2H1L1KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        hxL2H1L1KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column hxL2H2L1KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         hxL2H2L1KeyColumn.setName("H2L1_KEY");
-        hxL2H2L1KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        hxL2H2L1KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table hxL2Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         hxL2Table.setName("HX_L2");

--- a/instance/emf/tutorial/dimension/timedimension/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/dimension/timedimension/CatalogSupplier.java
+++ b/instance/emf/tutorial/dimension/timedimension/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/dimension/timedimension/CatalogSupplier.java
@@ -49,7 +49,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.09.01", source = Source.EMF, group = "Dimension") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -133,39 +133,39 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column dateKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         dateKeyColumn.setName("DATE_KEY");
-        dateKeyColumn.setType(SqlSimpleTypes.Sql99.timestampType());
+        dateKeyColumn.setType(SQLSimpleTypes.Sql99.timestampType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column yearIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         yearIdColumn.setName("YEAR_ID");
-        yearIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        yearIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column qtrIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         qtrIdColumn.setName("QTR_ID");
-        qtrIdColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        qtrIdColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column qtrNameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         qtrNameColumn.setName("QTR_NAME");
-        qtrNameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        qtrNameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column monthIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         monthIdColumn.setName("MONTH_ID");
-        monthIdColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        monthIdColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column monthNameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         monthNameColumn.setName("MONTH_NAME");
-        monthNameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        monthNameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column weekInMonthColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         weekInMonthColumn.setName("WEEK_IN_MONTH");
-        weekInMonthColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        weekInMonthColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column dayInMonthColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         dayInMonthColumn.setName("DAY_IN_MONTH");
-        dayInMonthColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        dayInMonthColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/formatter/cell/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/formatter/cell/CatalogSupplier.java
+++ b/instance/emf/tutorial/formatter/cell/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/formatter/cell/CatalogSupplier.java
@@ -40,7 +40,7 @@ import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.format.FormatFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.11.01", source = Source.EMF, group = "Formatter") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -88,11 +88,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/function/logic/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/function/logic/CatalogSupplier.java
+++ b/instance/emf/tutorial/function/logic/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/function/logic/CatalogSupplier.java
@@ -41,7 +41,7 @@ import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.03.06", source = Source.EMF, group = "Cube") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -76,11 +76,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/hierarchy/inlinetable/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/hierarchy/inlinetable/CatalogSupplier.java
+++ b/instance/emf/tutorial/hierarchy/inlinetable/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/hierarchy/inlinetable/CatalogSupplier.java
@@ -52,7 +52,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.16.01", source = Source.EMF, group = "Hierarchy") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -126,11 +126,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column dimKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         dimKeyColumn.setName("DIM_KEY");
-        dimKeyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        dimKeyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);
@@ -139,15 +139,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column htKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         htKeyColumn.setName("KEY");
-        htKeyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        htKeyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column htValueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         htValueColumn.setName("VALUE");
-        htValueColumn.setType(SqlSimpleTypes.numericType(18, 4));
+        htValueColumn.setType(SQLSimpleTypes.numericType(18, 4));
 
         Column htNameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         htNameColumn.setName("NAME");
-        htNameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        htNameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         DataSlot r1v1 = InstanceFactory.eINSTANCE.createDataSlot();
         r1v1.setFeature(htKeyColumn);

--- a/instance/emf/tutorial/hierarchy/uniquekeylevelname/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/hierarchy/uniquekeylevelname/CatalogSupplier.java
+++ b/instance/emf/tutorial/hierarchy/uniquekeylevelname/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/hierarchy/uniquekeylevelname/CatalogSupplier.java
@@ -47,7 +47,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.16.03", source = Source.EMF, group = "Hierarchy") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -131,67 +131,67 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column auotoDimIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         auotoDimIdColumn.setName("AUTO_DIM_ID");
-        auotoDimIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        auotoDimIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column makeIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         makeIdColumn.setName("MAKE_ID");
-        makeIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        makeIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column makeColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         makeColumn.setName("MAKE");
-        makeColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        makeColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column modelIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         modelIdColumn.setName("MODEL_ID");
-        modelIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        modelIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column modelColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         modelColumn.setName("MODEL");
-        modelColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        modelColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column plantIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         plantIdColumn.setName("PLANT_ID");
-        plantIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        plantIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column plantColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         plantColumn.setName("PLANT");
-        plantColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        plantColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column plantStateIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         plantStateIdColumn.setName("PLANT_STATE_ID");
-        plantStateIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        plantStateIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column plantCityIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         plantCityIdColumn.setName("PLANT_CITY_ID");
-        plantCityIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        plantCityIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column vehicleIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         vehicleIdColumn.setName("VEHICLE_ID");
-        vehicleIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        vehicleIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column colorIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         colorIdColumn.setName("COLOR_ID");
-        colorIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        colorIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column trimIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         trimIdColumn.setName("TRIM_ID");
-        trimIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        trimIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column licenseIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         licenseIdColumn.setName("LICENSE_ID");
-        licenseIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        licenseIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column licenseColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         licenseColumn.setName("LICENSE");
-        licenseColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        licenseColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column licenseStateIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         licenseStateIdColumn.setName("LICENSE_STATE_ID");
-        licenseStateIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        licenseStateIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column priceColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         priceColumn.setName("PRICE");
-        priceColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        priceColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/hierarchy/view/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/hierarchy/view/CatalogSupplier.java
+++ b/instance/emf/tutorial/hierarchy/view/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/hierarchy/view/CatalogSupplier.java
@@ -48,7 +48,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.16.02", source = Source.EMF, group = "Hierarchy") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -121,11 +121,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column dimKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         dimKeyColumn.setName("DIM_KEY");
-        dimKeyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        dimKeyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);
@@ -134,15 +134,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column nameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         nameColumn.setName("NAME");
-        nameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        nameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column htValueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         htValueColumn.setName("VALUE");
-        htValueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        htValueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table htTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         htTable.setName("HT");
@@ -158,15 +158,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyViewColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyViewColumn.setName("KEY");
-        keyViewColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        keyViewColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column nameViewColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         nameViewColumn.setName("NAME");
-        nameViewColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        nameViewColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column htValueViewColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         htValueViewColumn.setName("VALUE");
-        htValueViewColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        htValueViewColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         sqlView.getFeature().addAll(List.of(keyViewColumn, nameViewColumn, htValueViewColumn));
 

--- a/instance/emf/tutorial/kpi/all/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/kpi/all/CatalogSupplier.java
+++ b/instance/emf/tutorial/kpi/all/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/kpi/all/CatalogSupplier.java
@@ -43,7 +43,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.07.02", source = Source.EMF, group = "Kpi") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -94,15 +94,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueNumericColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueNumericColumn.setName("VALUE_NUMERIC");
-        valueNumericColumn.setType(SqlSimpleTypes.Sql99.numericType());
+        valueNumericColumn.setType(SQLSimpleTypes.Sql99.numericType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/kpi/intro/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/kpi/intro/CatalogSupplier.java
+++ b/instance/emf/tutorial/kpi/intro/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/kpi/intro/CatalogSupplier.java
@@ -40,7 +40,7 @@ import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.07.01", source = Source.EMF, group = "Kpi") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -87,7 +87,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/kpi/parent.ring/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/kpi/parent/ring/CatalogSupplier.java
+++ b/instance/emf/tutorial/kpi/parent.ring/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/kpi/parent/ring/CatalogSupplier.java
@@ -40,7 +40,7 @@ import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.07.03", source = Source.EMF, group = "Kpi") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -89,7 +89,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/instance/emf/tutorial/kpi/virtualcube/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/kpi/virtualcube/CatalogSupplier.java
+++ b/instance/emf/tutorial/kpi/virtualcube/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/kpi/virtualcube/CatalogSupplier.java
@@ -49,7 +49,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.07.04", source = Source.EMF, group = "Kpi") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -108,15 +108,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueNumericColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueNumericColumn.setName("VALUE_NUMERIC");
-        valueNumericColumn.setType(SqlSimpleTypes.Sql99.numericType());
+        valueNumericColumn.setType(SQLSimpleTypes.Sql99.numericType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/level/expressions/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/expressions/CatalogSupplier.java
+++ b/instance/emf/tutorial/level/expressions/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/expressions/CatalogSupplier.java
@@ -49,7 +49,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.14.01", source = Source.EMF, group = "Level") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -119,15 +119,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column key1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         key1Column.setName("KEY1");
-        key1Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        key1Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         SqlStatement nameSql = SourceFactory.eINSTANCE.createSqlStatement();
         nameSql.getDialects().addAll(List.of("generic", "h2"));

--- a/instance/emf/tutorial/level/ifblankname/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/ifblankname/CatalogSupplier.java
+++ b/instance/emf/tutorial/level/ifblankname/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/ifblankname/CatalogSupplier.java
@@ -48,7 +48,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.enumerations.NullableType;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.14.04", source = Source.EMF, group = "Level") // NOSONAR
@@ -146,11 +146,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column dimKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         dimKeyColumn.setName("DIM_KEY");
-        dimKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        dimKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table factTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         factTable.setName(FACT);
@@ -159,16 +159,16 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column level2NullKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level2NullKeyColumn.setName("KEY");
-        level2NullKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        level2NullKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column level2NullNameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level2NullNameColumn.setName("NAME");
-        level2NullNameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        level2NullNameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
         level2NullNameColumn.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         Column level2NullL1KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level2NullL1KeyColumn.setName("L1_KEY");
-        level2NullL1KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        level2NullL1KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table level2NullTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         level2NullTable.setName("Level_2_NULL");
@@ -177,11 +177,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column level1KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level1KeyColumn.setName("KEY");
-        level1KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        level1KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column level1NameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level1NameColumn.setName("NAME");
-        level1NameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        level1NameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
         level1NameColumn.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         Table level1Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();

--- a/instance/emf/tutorial/level/ifblanknamemultiple/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/ifblanknamemultiple/CatalogSupplier.java
+++ b/instance/emf/tutorial/level/ifblanknamemultiple/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/ifblanknamemultiple/CatalogSupplier.java
@@ -48,7 +48,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.enumerations.NullableType;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.14.04", source = Source.EMF, group = "Level") // NOSONAR
@@ -170,11 +170,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column factMultipleDimKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factMultipleDimKeyColumn.setName("DIM_KEY");
-        factMultipleDimKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        factMultipleDimKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column factMultipleValueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factMultipleValueColumn.setName("VALUE");
-        factMultipleValueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        factMultipleValueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table factMultipleTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         factMultipleTable.setName("Fact_Multiple");
@@ -183,11 +183,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column level1MultipleKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level1MultipleKeyColumn.setName("KEY");
-        level1MultipleKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        level1MultipleKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column level1MultipleNameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level1MultipleNameColumn.setName("NAME");
-        level1MultipleNameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        level1MultipleNameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
         level1MultipleNameColumn.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         Table level1MultipleTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
@@ -197,16 +197,16 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column level2MultipleKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level2MultipleKeyColumn.setName("KEY");
-        level2MultipleKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        level2MultipleKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column level2MultipleNameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level2MultipleNameColumn.setName("NAME");
-        level2MultipleNameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        level2MultipleNameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
         level2MultipleNameColumn.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         Column level2MultipleL1KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level2MultipleL1KeyColumn.setName("L1_KEY");
-        level2MultipleL1KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        level2MultipleL1KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table level2MultipleTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         level2MultipleTable.setName("Level_2_Multiple");
@@ -215,16 +215,16 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column level3MultipleKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level3MultipleKeyColumn.setName("KEY");
-        level3MultipleKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        level3MultipleKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column level3MultipleNameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level3MultipleNameColumn.setName("NAME");
-        level3MultipleNameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        level3MultipleNameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
         level3MultipleNameColumn.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         Column level3MultipleL2KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level3MultipleL2KeyColumn.setName("L2_KEY");
-        level3MultipleL2KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        level3MultipleL2KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table level3MultipleTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         level3MultipleTable.setName("Level_3_Multiple");

--- a/instance/emf/tutorial/level/ifparentsname/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/ifparentsname/CatalogSupplier.java
+++ b/instance/emf/tutorial/level/ifparentsname/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/ifparentsname/CatalogSupplier.java
@@ -48,7 +48,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.14.03", source = Source.EMF, group = "Level") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -145,11 +145,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column dimKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         dimKeyColumn.setName("DIM_KEY");
-        dimKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        dimKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table factTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         factTable.setName(FACT);
@@ -158,11 +158,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column level1KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level1KeyColumn.setName("KEY");
-        level1KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        level1KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column level1NameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level1NameColumn.setName("NAME");
-        level1NameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        level1NameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table level1Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         level1Table.setName("Level_1");
@@ -171,15 +171,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column level2KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level2KeyColumn.setName("KEY");
-        level2KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        level2KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column level2NameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level2NameColumn.setName("NAME");
-        level2NameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        level2NameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column level2L1KeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         level2L1KeyColumn.setName("L1_KEY");
-        level2L1KeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        level2L1KeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table level2Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         level2Table.setName("Level_2");

--- a/instance/emf/tutorial/level/ordinalcolumns/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/ordinalcolumns/CatalogSupplier.java
+++ b/instance/emf/tutorial/level/ordinalcolumns/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/ordinalcolumns/CatalogSupplier.java
@@ -48,7 +48,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.14.06", source = Source.EMF, group = "Level") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -117,15 +117,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnKey = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnKey.setName("KEY");
-        columnKey.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnKey.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnValue = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnValue.setName("VALUE");
-        columnValue.setType(SqlSimpleTypes.Sql99.integerType());
+        columnValue.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnCountry = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnCountry.setName("COUNTRY");
-        columnCountry.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnCountry.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableFact = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableFact.setName("Fact");

--- a/instance/emf/tutorial/level/relationalsource/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/relationalsource/CatalogSupplier.java
+++ b/instance/emf/tutorial/level/relationalsource/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/relationalsource/CatalogSupplier.java
@@ -48,7 +48,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.14.08", source = Source.EMF, group = "Level") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -113,11 +113,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column employeeIdFactColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         employeeIdFactColumn.setName("employee_id");
-        employeeIdFactColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        employeeIdFactColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column salaryFactColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         salaryFactColumn.setName("salary");
-        salaryFactColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        salaryFactColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table factTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         factTable.setName(FACT);
@@ -126,20 +126,20 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column employeeIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         employeeIdColumn.setName("employee_id");
-        employeeIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        employeeIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column supervisorIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         supervisorIdColumn.setName("supervisor_id");
-        supervisorIdColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        supervisorIdColumn.setType(SQLSimpleTypes.Sql99.integerType());
         supervisorIdColumn.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         Column nameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         nameColumn.setName("name");
-        nameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        nameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column managementRroleColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         managementRroleColumn.setName("management_role");
-        managementRroleColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        managementRroleColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table employeeTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         employeeTable.setName(EMPLOYEE);

--- a/instance/emf/tutorial/level/smallintasbooleantype/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/smallintasbooleantype/CatalogSupplier.java
+++ b/instance/emf/tutorial/level/smallintasbooleantype/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/smallintasbooleantype/CatalogSupplier.java
@@ -46,7 +46,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.14.02", source = Source.EMF, group = "Level") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -109,15 +109,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column flagColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         flagColumn.setName("FLAG");
-        flagColumn.setType(SqlSimpleTypes.Sql99.smallintType());
+        flagColumn.setType(SQLSimpleTypes.Sql99.smallintType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/level/unique/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/unique/CatalogSupplier.java
+++ b/instance/emf/tutorial/level/unique/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/level/unique/CatalogSupplier.java
@@ -45,7 +45,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.14.05", source = Source.EMF, group = "Level") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -114,19 +114,19 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column buildingColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         buildingColumn.setName("BUILDING");
-        buildingColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        buildingColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column roomColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         roomColumn.setName("ROOM");
-        roomColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        roomColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table factTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         factTable.setName(FACT);

--- a/instance/emf/tutorial/measure/expression/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/measure/expression/CatalogSupplier.java
+++ b/instance/emf/tutorial/measure/expression/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/measure/expression/CatalogSupplier.java
@@ -40,7 +40,7 @@ import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.12.01", source = Source.EMF, group = "Measure") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -100,15 +100,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueNumericColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueNumericColumn.setName("VALUE_NUMERIC");
-        valueNumericColumn.setType(SqlSimpleTypes.numericType(18, 4));
+        valueNumericColumn.setType(SQLSimpleTypes.numericType(18, 4));
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);
@@ -117,15 +117,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column idColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         idColumn.setName("ID");
-        idColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        idColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column value1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         value1Column.setName("VALUE");
-        value1Column.setType(SqlSimpleTypes.Sql99.integerType());
+        value1Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column flagColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         flagColumn.setName("FLAG");
-        flagColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        flagColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         SqlStatement sql1 = SourceFactory.eINSTANCE.createSqlStatement();
         sql1.getDialects().addAll(List.of("generic", "h2"));

--- a/instance/emf/tutorial/measure/inlinetable/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/measure/inlinetable/CatalogSupplier.java
+++ b/instance/emf/tutorial/measure/inlinetable/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/measure/inlinetable/CatalogSupplier.java
@@ -43,7 +43,7 @@ import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.12.02", source = Source.EMF, group = "Measure") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -88,11 +88,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         DataSlot rowValue1 = InstanceFactory.eINSTANCE.createDataSlot();
         rowValue1.setFeature(keyColumn);

--- a/instance/emf/tutorial/measure/inlinetablewithphysical/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/measure/inlinetablewithphysical/CatalogSupplier.java
+++ b/instance/emf/tutorial/measure/inlinetablewithphysical/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/measure/inlinetablewithphysical/CatalogSupplier.java
@@ -54,7 +54,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.12.03", source = Source.EMF, group = "Measure") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -144,15 +144,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column townKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         townKeyColumn.setName("KEY");
-        townKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        townKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column townCountryKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         townCountryKeyColumn.setName("KEY_COUNTRY");
-        townCountryKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        townCountryKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column townNameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         townNameColumn.setName("NAME");
-        townNameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        townNameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table townTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         townTable.setName("TOWN");
@@ -161,11 +161,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column countryKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         countryKeyColumn.setName("KEY");
-        countryKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        countryKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column countryNameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         countryNameColumn.setName("NAME");
-        countryNameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        countryNameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         DataSlot rowCountryValue11 = InstanceFactory.eINSTANCE.createDataSlot();
         rowCountryValue11.setFeature(countryKeyColumn);
@@ -200,11 +200,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.doublePrecisionType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.doublePrecisionType());
 
         DataSlot rowValue11 = InstanceFactory.eINSTANCE.createDataSlot();
         rowValue11.setFeature(keyColumn);

--- a/instance/emf/tutorial/member/identifier/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/member/identifier/CatalogSupplier.java
+++ b/instance/emf/tutorial/member/identifier/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/member/identifier/CatalogSupplier.java
@@ -45,7 +45,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.06.01", source = Source.EMF, group = "Member") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -103,15 +103,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnKey1 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnKey1.setName("KEY1");
-        columnKey1.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnKey1.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnValue = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnValue.setName("VALUE");
-        columnValue.setType(SqlSimpleTypes.Sql99.integerType());
+        columnValue.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnKey2 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnKey2.setName("KEY2");
-        columnKey2.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnKey2.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableFact = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableFact.setName("Fact");

--- a/instance/emf/tutorial/member/property.geo/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/member/property/geo/CatalogSupplier.java
+++ b/instance/emf/tutorial/member/property.geo/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/member/property/geo/CatalogSupplier.java
@@ -49,7 +49,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.06.02.02", source = Source.EMF, group = "Member") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -150,11 +150,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         // Fact table columns
         Column columnFactMemberId = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnFactMemberId.setName("MEMBER_ID");
-        columnFactMemberId.setType(SqlSimpleTypes.Sql99.integerType());
+        columnFactMemberId.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnFactValue = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnFactValue.setName("VALUE");
-        columnFactValue.setType(SqlSimpleTypes.decimalType(18, 4));
+        columnFactValue.setType(SQLSimpleTypes.decimalType(18, 4));
 
         Table tableFact = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableFact.setName("Fact");
@@ -164,27 +164,27 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         // Member table columns
         Column columnMemberId = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnMemberId.setName("ID");
-        columnMemberId.setType(SqlSimpleTypes.Sql99.integerType());
+        columnMemberId.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnMemberName = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnMemberName.setName("NAME");
-        columnMemberName.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnMemberName.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnMemberLocation = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnMemberLocation.setName("LOCATION");
-        columnMemberLocation.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnMemberLocation.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnMemberLatitude = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnMemberLatitude.setName("LATITUDE");
-        columnMemberLatitude.setType(SqlSimpleTypes.decimalType(18, 4));
+        columnMemberLatitude.setType(SQLSimpleTypes.decimalType(18, 4));
 
         Column columnMemberLongitude = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnMemberLongitude.setName("LONGITUDE");
-        columnMemberLongitude.setType(SqlSimpleTypes.decimalType(18, 4));
+        columnMemberLongitude.setType(SQLSimpleTypes.decimalType(18, 4));
 
         Column columnMemberDescription = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnMemberDescription.setName("DESCRIPTION");
-        columnMemberDescription.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnMemberDescription.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableMember = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableMember.setName("Member");

--- a/instance/emf/tutorial/member/property.intro/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/member/property/intro/CatalogSupplier.java
+++ b/instance/emf/tutorial/member/property.intro/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/member/property/intro/CatalogSupplier.java
@@ -47,7 +47,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.06.02.01", source = Source.EMF, group = "Member") // NOSONAR
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -108,11 +108,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnFactTownId = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnFactTownId.setName("TOWN_ID");
-        columnFactTownId.setType(SqlSimpleTypes.Sql99.integerType());
+        columnFactTownId.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnFactValue = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnFactValue.setName("VALUE");
-        columnFactValue.setType(SqlSimpleTypes.Sql99.integerType());
+        columnFactValue.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table tableFact = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableFact.setName("Fact");
@@ -121,15 +121,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column columnTownId = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTownId.setName("ID");
-        columnTownId.setType(SqlSimpleTypes.Sql99.integerType());
+        columnTownId.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column columnTownName = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTownName.setName("NAME");
-        columnTownName.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnTownName.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column columnTownCapital = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         columnTownCapital.setName("CAPITAL");
-        columnTownCapital.setType(SqlSimpleTypes.Sql99.varcharType());
+        columnTownCapital.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table tableTown = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         tableTown.setName("Town");

--- a/instance/emf/tutorial/namedset/all/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/namedset/CatalogSupplier.java
+++ b/instance/emf/tutorial/namedset/all/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/namedset/CatalogSupplier.java
@@ -47,7 +47,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.08.01", source = Source.EMF, group = "Namedset") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -128,11 +128,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/parentchild/link/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/parentchild/link/CatalogSupplier.java
+++ b/instance/emf/tutorial/parentchild/link/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/parentchild/link/CatalogSupplier.java
@@ -46,7 +46,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.17.02", source = Source.EMF, group = "Parent Child") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -122,15 +122,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column nameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         nameColumn.setName("NAME");
-        nameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        nameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column parentColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         parentColumn.setName("PARENT");
-        parentColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        parentColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);
@@ -139,15 +139,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column closureNameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         closureNameColumn.setName("NAME");
-        closureNameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        closureNameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column closureParentColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         closureParentColumn.setName("PARENT");
-        closureParentColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        closureParentColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column closureDistanceColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         closureDistanceColumn.setName("DISTANCE");
-        closureDistanceColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        closureDistanceColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table closureTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         closureTable.setName("Closure");

--- a/instance/emf/tutorial/parentchild/minimal/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/parentchild/minimal/CatalogSupplier.java
+++ b/instance/emf/tutorial/parentchild/minimal/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/parentchild/minimal/CatalogSupplier.java
@@ -45,7 +45,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.enumerations.NullableType;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.17.01", source = Source.EMF, group = "Parent Child") // NOSONAR
@@ -114,11 +114,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column dimKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         dimKeyColumn.setName("DIM_KEY");
-        dimKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        dimKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);
@@ -127,15 +127,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column memberKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         memberKeyColumn.setName("KEY");
-        memberKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        memberKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column memberNameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         memberNameColumn.setName("NAME");
-        memberNameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        memberNameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column memberParentKeyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         memberParentKeyColumn.setName("PARENT_KEY");
-        memberParentKeyColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        memberParentKeyColumn.setType(SQLSimpleTypes.Sql99.integerType());
         memberParentKeyColumn.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         Table table1 = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();

--- a/instance/emf/tutorial/parentchild/nullparent/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/parentchild/nullparent/CatalogSupplier.java
+++ b/instance/emf/tutorial/parentchild/nullparent/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/parentchild/nullparent/CatalogSupplier.java
@@ -45,7 +45,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.17.02", source = Source.EMF, group = "Parent Child") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -112,15 +112,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column nameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         nameColumn.setName("NAME");
-        nameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        nameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column parentColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         parentColumn.setName("PARENT");
-        parentColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        parentColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(PARENT);

--- a/instance/emf/tutorial/parentchild/parentasleaf/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/parentchild/parentasleaf/CatalogSupplier.java
+++ b/instance/emf/tutorial/parentchild/parentasleaf/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/parentchild/parentasleaf/CatalogSupplier.java
@@ -45,7 +45,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.17.04", source = Source.EMF, group = "Parent Child") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -112,15 +112,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column nameColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         nameColumn.setName("NAME");
-        nameColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        nameColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column parentColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         parentColumn.setName("PARENT");
-        parentColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        parentColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(PARENT);

--- a/instance/emf/tutorial/virtualcube/calculatedmember/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/virtualcube/calculatedmember/CatalogSupplier.java
+++ b/instance/emf/tutorial/virtualcube/calculatedmember/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/virtualcube/calculatedmember/CatalogSupplier.java
@@ -47,7 +47,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.15.03", source = Source.EMF, group = "VirtualCube") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -118,11 +118,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/virtualcube/dimensions/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/virtualcube/dimensions/CatalogSupplier.java
+++ b/instance/emf/tutorial/virtualcube/dimensions/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/virtualcube/dimensions/CatalogSupplier.java
@@ -46,7 +46,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.15.02", source = Source.EMF, group = "VirtualCube") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -111,11 +111,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);

--- a/instance/emf/tutorial/virtualcube/min/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/virtualcube/min/CatalogSupplier.java
+++ b/instance/emf/tutorial/virtualcube/min/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/virtualcube/min/CatalogSupplier.java
@@ -42,7 +42,7 @@ import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.15.01", source = Source.EMF, group = "VirtualCube") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -115,11 +115,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column key1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         key1Column.setName("KEY");
-        key1Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        key1Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column value1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         value1Column.setName("VALUE");
-        value1Column.setType(SqlSimpleTypes.Sql99.integerType());
+        value1Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table c1Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         c1Table.setName(C1_FACT);
@@ -128,11 +128,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column key2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         key2Column.setName("KEY");
-        key2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        key2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column value2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         value2Column.setName("VALUE");
-        value2Column.setType(SqlSimpleTypes.Sql99.integerType());
+        value2Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table c2Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         c2Table.setName(C2_FACT);

--- a/instance/emf/tutorial/virtualcube/unvisiblereferencecubes/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/virtualcube/unvisiblereferencecubes/CatalogSupplier.java
+++ b/instance/emf/tutorial/virtualcube/unvisiblereferencecubes/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/virtualcube/unvisiblereferencecubes/CatalogSupplier.java
@@ -46,7 +46,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.15.04", source = Source.EMF, group = "VirtualCube") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -116,11 +116,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Table c1Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         c1Table.setName(FACT);

--- a/instance/emf/tutorial/writeback/decimalandcomment/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/decimalandcomment/CatalogSupplier.java
+++ b/instance/emf/tutorial/writeback/decimalandcomment/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/decimalandcomment/CatalogSupplier.java
@@ -17,7 +17,7 @@ import java.util.List;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 
 import org.eclipse.daanse.rolap.mapping.instance.api.CatalogRef;
 import org.eclipse.daanse.rolap.mapping.instance.api.DocSection;
@@ -166,22 +166,22 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         databaseSchema = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE
                 .createSchema();
 
-        Column factProductColumn = createColumn("PRODUCT", SqlSimpleTypes.Sql99.varcharType());
-        Column factAmountColumn = createColumn("AMOUNT", SqlSimpleTypes.decimalType(18, 2));
-        Column factCommentColumn = createColumn("COMMENT", SqlSimpleTypes.Sql99.varcharType());
+        Column factProductColumn = createColumn("PRODUCT", SQLSimpleTypes.Sql99.varcharType());
+        Column factAmountColumn = createColumn("AMOUNT", SQLSimpleTypes.decimalType(18, 2));
+        Column factCommentColumn = createColumn("COMMENT", SQLSimpleTypes.Sql99.varcharType());
         Table factTable = createTable(FACT, List.of(factProductColumn, factAmountColumn, factCommentColumn));
         databaseSchema.getOwnedElement().add(factTable);
 
-        Column productKeyColumn = createColumn("KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column productNameColumn = createColumn("NAME", SqlSimpleTypes.Sql99.varcharType());
+        Column productKeyColumn = createColumn("KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column productNameColumn = createColumn("NAME", SQLSimpleTypes.Sql99.varcharType());
         Table productTable = createTable(PRODUCT, List.of(productKeyColumn, productNameColumn));
         databaseSchema.getOwnedElement().add(productTable);
 
-        Column wbProductColumn = createColumn("PRODUCT", SqlSimpleTypes.Sql99.varcharType());
-        Column wbAmountColumn = createColumn("AMOUNT", SqlSimpleTypes.decimalType(18, 2));
-        Column wbCommentColumn = createColumn("COMMENT", SqlSimpleTypes.Sql99.varcharType());
-        Column wbIdColumn = createColumn("ID", SqlSimpleTypes.Sql99.varcharType());
-        Column wbUserColumn = createColumn("USER", SqlSimpleTypes.Sql99.varcharType());
+        Column wbProductColumn = createColumn("PRODUCT", SQLSimpleTypes.Sql99.varcharType());
+        Column wbAmountColumn = createColumn("AMOUNT", SQLSimpleTypes.decimalType(18, 2));
+        Column wbCommentColumn = createColumn("COMMENT", SQLSimpleTypes.Sql99.varcharType());
+        Column wbIdColumn = createColumn("ID", SQLSimpleTypes.Sql99.varcharType());
+        Column wbUserColumn = createColumn("USER", SQLSimpleTypes.Sql99.varcharType());
         Table writebackPhysicalTable = createTable(FACTWB,
                 List.of(wbProductColumn, wbAmountColumn, wbCommentColumn, wbIdColumn, wbUserColumn));
         databaseSchema.getOwnedElement().add(writebackPhysicalTable);

--- a/instance/emf/tutorial/writeback/decimalandcommentandmultidim/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/decimalandcommentandmultidim/CatalogSupplier.java
+++ b/instance/emf/tutorial/writeback/decimalandcommentandmultidim/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/decimalandcommentandmultidim/CatalogSupplier.java
@@ -17,7 +17,7 @@ import java.util.List;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 
 import org.eclipse.daanse.rolap.mapping.instance.api.CatalogRef;
 import org.eclipse.daanse.rolap.mapping.instance.api.DocSection;
@@ -189,33 +189,33 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         databaseSchema = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE
                 .createSchema();
 
-        Column factProductColumn = createColumn("PRODUCT", SqlSimpleTypes.Sql99.varcharType());
-        Column factCityColumn = createColumn("CITY", SqlSimpleTypes.Sql99.varcharType());
-        Column factAmountColumn = createColumn("AMOUNT", SqlSimpleTypes.decimalType(18, 2));
-        Column factCommentColumn = createColumn("COMMENT", SqlSimpleTypes.Sql99.varcharType());
+        Column factProductColumn = createColumn("PRODUCT", SQLSimpleTypes.Sql99.varcharType());
+        Column factCityColumn = createColumn("CITY", SQLSimpleTypes.Sql99.varcharType());
+        Column factAmountColumn = createColumn("AMOUNT", SQLSimpleTypes.decimalType(18, 2));
+        Column factCommentColumn = createColumn("COMMENT", SQLSimpleTypes.Sql99.varcharType());
         Table factTable = createTable(FACT,
                 List.of(factProductColumn, factCityColumn, factAmountColumn, factCommentColumn));
         databaseSchema.getOwnedElement().add(factTable);
 
-        Column productKeyColumn = createColumn("KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column productNameColumn = createColumn("NAME", SqlSimpleTypes.Sql99.varcharType());
+        Column productKeyColumn = createColumn("KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column productNameColumn = createColumn("NAME", SQLSimpleTypes.Sql99.varcharType());
         Table productTable = createTable(PRODUCT, List.of(productKeyColumn, productNameColumn));
         databaseSchema.getOwnedElement().add(productTable);
 
-        Column countryKeyColumn = createColumn("COUNTRY_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column countryNameColumn = createColumn("COUNTRY_NAME", SqlSimpleTypes.Sql99.varcharType());
-        Column cityKeyColumn = createColumn("CITY_KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column cityNameColumn = createColumn("CITY_NAME", SqlSimpleTypes.Sql99.varcharType());
+        Column countryKeyColumn = createColumn("COUNTRY_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column countryNameColumn = createColumn("COUNTRY_NAME", SQLSimpleTypes.Sql99.varcharType());
+        Column cityKeyColumn = createColumn("CITY_KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column cityNameColumn = createColumn("CITY_NAME", SQLSimpleTypes.Sql99.varcharType());
         Table regionTable = createTable(REGION,
                 List.of(countryKeyColumn, countryNameColumn, cityKeyColumn, cityNameColumn));
         databaseSchema.getOwnedElement().add(regionTable);
 
-        Column wbProductColumn = createColumn("PRODUCT", SqlSimpleTypes.Sql99.varcharType());
-        Column wbCityColumn = createColumn("CITY", SqlSimpleTypes.Sql99.varcharType());
-        Column wbAmountColumn = createColumn("AMOUNT", SqlSimpleTypes.decimalType(18, 2));
-        Column wbCommentColumn = createColumn("COMMENT", SqlSimpleTypes.Sql99.varcharType());
-        Column wbIdColumn = createColumn("ID", SqlSimpleTypes.Sql99.varcharType());
-        Column wbUserColumn = createColumn("USER", SqlSimpleTypes.Sql99.varcharType());
+        Column wbProductColumn = createColumn("PRODUCT", SQLSimpleTypes.Sql99.varcharType());
+        Column wbCityColumn = createColumn("CITY", SQLSimpleTypes.Sql99.varcharType());
+        Column wbAmountColumn = createColumn("AMOUNT", SQLSimpleTypes.decimalType(18, 2));
+        Column wbCommentColumn = createColumn("COMMENT", SQLSimpleTypes.Sql99.varcharType());
+        Column wbIdColumn = createColumn("ID", SQLSimpleTypes.Sql99.varcharType());
+        Column wbUserColumn = createColumn("USER", SQLSimpleTypes.Sql99.varcharType());
         Table writebackPhysicalTable = createTable(FACTWB,
                 List.of(wbProductColumn, wbCityColumn, wbAmountColumn, wbCommentColumn, wbIdColumn, wbUserColumn));
         databaseSchema.getOwnedElement().add(writebackPhysicalTable);

--- a/instance/emf/tutorial/writeback/inlinetable/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/inlinetable/CatalogSupplier.java
+++ b/instance/emf/tutorial/writeback/inlinetable/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/inlinetable/CatalogSupplier.java
@@ -58,7 +58,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.05.01", source = Source.EMF, group = "Writeback") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -132,15 +132,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column valColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valColumn.setName("VAL");
-        valColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column val1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         val1Column.setName("VAL1");
-        val1Column.setType(SqlSimpleTypes.Sql99.integerType());
+        val1Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column l2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         l2Column.setName("L2");
-        l2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        l2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         DataSlot r1V1 = InstanceFactory.eINSTANCE.createDataSlot();
         r1V1.setFeature(valColumn);
@@ -211,11 +211,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column l1L1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         l1L1Column.setName("L1");
-        l1L1Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        l1L1Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column l1L2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         l1L2Column.setName("L2");
-        l1L2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        l1L2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table l1Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         l1Table.setName("L1");
@@ -224,7 +224,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column l2L2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         l2L2Column.setName("L2");
-        l2L2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        l2L2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table l2Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         l2Table.setName("L2");
@@ -233,23 +233,23 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column factwbValColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbValColumn.setName("VAL");
-        factwbValColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        factwbValColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column factwbVal1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbVal1Column.setName("VAL1");
-        factwbVal1Column.setType(SqlSimpleTypes.Sql99.integerType());
+        factwbVal1Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column factwbL2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbL2Column.setName("L2");
-        factwbL2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        factwbL2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column factwbIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbIdColumn.setName("ID");
-        factwbIdColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        factwbIdColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column factwbUserColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbUserColumn.setName("USER");
-        factwbUserColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        factwbUserColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table factwbTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         factwbTable.setName("FACTWB");

--- a/instance/emf/tutorial/writeback/parentchild/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/parentchild/CatalogSupplier.java
+++ b/instance/emf/tutorial/writeback/parentchild/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/parentchild/CatalogSupplier.java
@@ -17,7 +17,7 @@ import java.util.List;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 
 import org.eclipse.daanse.rolap.mapping.instance.api.CatalogRef;
 import org.eclipse.daanse.rolap.mapping.instance.api.DocSection;
@@ -187,21 +187,21 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         databaseSchema = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE
                 .createSchema();
 
-        Column factNodeColumn = createColumn("NODE", SqlSimpleTypes.Sql99.varcharType());
-        Column factValueColumn = createColumn("VALUE", SqlSimpleTypes.Sql99.integerType());
+        Column factNodeColumn = createColumn("NODE", SQLSimpleTypes.Sql99.varcharType());
+        Column factValueColumn = createColumn("VALUE", SQLSimpleTypes.Sql99.integerType());
         Table factTable = createTable(FACT, List.of(factNodeColumn, factValueColumn));
         databaseSchema.getOwnedElement().add(factTable);
 
-        Column nodeKeyColumn = createColumn("KEY", SqlSimpleTypes.Sql99.varcharType());
-        Column nodeNameColumn = createColumn("NAME", SqlSimpleTypes.Sql99.varcharType());
-        Column nodeParentKeyColumn = createColumn("PARENT_KEY", SqlSimpleTypes.Sql99.varcharType());
+        Column nodeKeyColumn = createColumn("KEY", SQLSimpleTypes.Sql99.varcharType());
+        Column nodeNameColumn = createColumn("NAME", SQLSimpleTypes.Sql99.varcharType());
+        Column nodeParentKeyColumn = createColumn("PARENT_KEY", SQLSimpleTypes.Sql99.varcharType());
         Table nodeTable = createTable(NODE, List.of(nodeKeyColumn, nodeNameColumn, nodeParentKeyColumn));
         databaseSchema.getOwnedElement().add(nodeTable);
 
-        Column wbNodeColumn = createColumn("NODE", SqlSimpleTypes.Sql99.varcharType());
-        Column wbValueColumn = createColumn("VALUE", SqlSimpleTypes.Sql99.integerType());
-        Column wbIdColumn = createColumn("ID", SqlSimpleTypes.Sql99.varcharType());
-        Column wbUserColumn = createColumn("USER", SqlSimpleTypes.Sql99.varcharType());
+        Column wbNodeColumn = createColumn("NODE", SQLSimpleTypes.Sql99.varcharType());
+        Column wbValueColumn = createColumn("VALUE", SQLSimpleTypes.Sql99.integerType());
+        Column wbIdColumn = createColumn("ID", SQLSimpleTypes.Sql99.varcharType());
+        Column wbUserColumn = createColumn("USER", SQLSimpleTypes.Sql99.varcharType());
         Table writebackPhysicalTable = createTable(FACTWB,
                 List.of(wbNodeColumn, wbValueColumn, wbIdColumn, wbUserColumn));
         databaseSchema.getOwnedElement().add(writebackPhysicalTable);

--- a/instance/emf/tutorial/writeback/table/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/table/CatalogSupplier.java
+++ b/instance/emf/tutorial/writeback/table/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/table/CatalogSupplier.java
@@ -51,7 +51,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.05.02", source = Source.EMF, group = "Writeback") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -126,15 +126,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column valColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valColumn.setName("VAL");
-        valColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column val1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         val1Column.setName("VAL1");
-        val1Column.setType(SqlSimpleTypes.Sql99.integerType());
+        val1Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column l2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         l2Column.setName("L2");
-        l2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        l2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);
@@ -143,11 +143,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column l1L1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         l1L1Column.setName("L1");
-        l1L1Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        l1L1Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column l1L2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         l1L2Column.setName("L2");
-        l1L2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        l1L2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table l1Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         l1Table.setName("L1");
@@ -156,7 +156,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column l2L2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         l2L2Column.setName("L2");
-        l2L2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        l2L2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table l2Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         l2Table.setName("L2");
@@ -165,23 +165,23 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column factwbValColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbValColumn.setName("VAL");
-        factwbValColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        factwbValColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column factwbVal1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbVal1Column.setName("VAL1");
-        factwbVal1Column.setType(SqlSimpleTypes.Sql99.integerType());
+        factwbVal1Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column factwbL2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbL2Column.setName("L2");
-        factwbL2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        factwbL2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column factwbIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbIdColumn.setName("ID");
-        factwbIdColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        factwbIdColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column factwbUserColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbUserColumn.setName("USER");
-        factwbUserColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        factwbUserColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table factwbTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         factwbTable.setName("FACTWB");

--- a/instance/emf/tutorial/writeback/textagg/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/textagg/CatalogSupplier.java
+++ b/instance/emf/tutorial/writeback/textagg/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/textagg/CatalogSupplier.java
@@ -17,7 +17,7 @@ import java.util.List;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 
 import org.eclipse.daanse.rolap.mapping.instance.api.CatalogRef;
 import org.eclipse.daanse.rolap.mapping.instance.api.DocSection;
@@ -185,22 +185,22 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         databaseSchema = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE
                 .createSchema();
 
-        Column factCategoryColumn = createColumn("CATEGORY", SqlSimpleTypes.Sql99.varcharType());
-        Column factAmountColumn = createColumn("AMOUNT", SqlSimpleTypes.Sql99.integerType());
-        Column factCommentColumn = createColumn("COMMENT", SqlSimpleTypes.Sql99.varcharType());
+        Column factCategoryColumn = createColumn("CATEGORY", SQLSimpleTypes.Sql99.varcharType());
+        Column factAmountColumn = createColumn("AMOUNT", SQLSimpleTypes.Sql99.integerType());
+        Column factCommentColumn = createColumn("COMMENT", SQLSimpleTypes.Sql99.varcharType());
         Table factTable = createTable(FACT, List.of(factCategoryColumn, factAmountColumn, factCommentColumn));
         databaseSchema.getOwnedElement().add(factTable);
 
-        Column catCategoryColumn = createColumn("CATEGORY", SqlSimpleTypes.Sql99.varcharType());
-        Column catNameColumn = createColumn("NAME", SqlSimpleTypes.Sql99.varcharType());
+        Column catCategoryColumn = createColumn("CATEGORY", SQLSimpleTypes.Sql99.varcharType());
+        Column catNameColumn = createColumn("NAME", SQLSimpleTypes.Sql99.varcharType());
         Table categoryTable = createTable(CATEGORY, List.of(catCategoryColumn, catNameColumn));
         databaseSchema.getOwnedElement().add(categoryTable);
 
-        Column wbCategoryColumn = createColumn("CATEGORY", SqlSimpleTypes.Sql99.varcharType());
-        Column wbAmountColumn = createColumn("AMOUNT", SqlSimpleTypes.Sql99.integerType());
-        Column wbCommentColumn = createColumn("COMMENT", SqlSimpleTypes.Sql99.varcharType());
-        Column wbIdColumn = createColumn("ID", SqlSimpleTypes.Sql99.varcharType());
-        Column wbUserColumn = createColumn("USER", SqlSimpleTypes.Sql99.varcharType());
+        Column wbCategoryColumn = createColumn("CATEGORY", SQLSimpleTypes.Sql99.varcharType());
+        Column wbAmountColumn = createColumn("AMOUNT", SQLSimpleTypes.Sql99.integerType());
+        Column wbCommentColumn = createColumn("COMMENT", SQLSimpleTypes.Sql99.varcharType());
+        Column wbIdColumn = createColumn("ID", SQLSimpleTypes.Sql99.varcharType());
+        Column wbUserColumn = createColumn("USER", SQLSimpleTypes.Sql99.varcharType());
         Table writebackPhysicalTable = createTable(FACTWB,
                 List.of(wbCategoryColumn, wbAmountColumn, wbCommentColumn, wbIdColumn, wbUserColumn));
         databaseSchema.getOwnedElement().add(writebackPhysicalTable);

--- a/instance/emf/tutorial/writeback/view/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/view/CatalogSupplier.java
+++ b/instance/emf/tutorial/writeback/view/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/view/CatalogSupplier.java
@@ -54,7 +54,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.05.03", source = Source.EMF, group = "Writeback") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -129,15 +129,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column valColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valColumn.setName("VAL");
-        valColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column val1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         val1Column.setName("VAL1");
-        val1Column.setType(SqlSimpleTypes.Sql99.integerType());
+        val1Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column l2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         l2Column.setName("L2");
-        l2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        l2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         SqlStatement sqlStatement = SourceFactory.eINSTANCE.createSqlStatement();
         sqlStatement.getDialects().addAll(List.of("generic", "h1"));
@@ -150,11 +150,11 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column l1L1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         l1L1Column.setName("L1");
-        l1L1Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        l1L1Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column l1L2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         l1L2Column.setName("L2");
-        l1L2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        l1L2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table l1Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         l1Table.setName("L1");
@@ -163,7 +163,7 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column l2L2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         l2L2Column.setName("L2");
-        l2L2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        l2L2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table l2Table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         l2Table.setName("L2");
@@ -172,23 +172,23 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column factwbValColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbValColumn.setName("VAL");
-        factwbValColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        factwbValColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column factwbVal1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbVal1Column.setName("VAL1");
-        factwbVal1Column.setType(SqlSimpleTypes.Sql99.integerType());
+        factwbVal1Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column factwbL2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbL2Column.setName("L2");
-        factwbL2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        factwbL2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column factwbIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbIdColumn.setName("ID");
-        factwbIdColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        factwbIdColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column factwbUserColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbUserColumn.setName("USER");
-        factwbUserColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        factwbUserColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table factwbTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         factwbTable.setName("FACTWB");

--- a/instance/emf/tutorial/writeback/virtualcube/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/virtualcube/CatalogSupplier.java
+++ b/instance/emf/tutorial/writeback/virtualcube/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/virtualcube/CatalogSupplier.java
@@ -17,7 +17,7 @@ import java.util.List;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 
 import org.eclipse.daanse.rolap.mapping.instance.api.CatalogRef;
 import org.eclipse.daanse.rolap.mapping.instance.api.DocSection;
@@ -207,37 +207,37 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
         databaseSchema = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE
                 .createSchema();
 
-        Column factNCategoryColumn = createColumn("CATEGORY", SqlSimpleTypes.Sql99.varcharType());
-        Column factNRegionColumn = createColumn("REGION", SqlSimpleTypes.Sql99.varcharType());
-        Column factNAmountColumn = createColumn("AMOUNT", SqlSimpleTypes.Sql99.integerType());
+        Column factNCategoryColumn = createColumn("CATEGORY", SQLSimpleTypes.Sql99.varcharType());
+        Column factNRegionColumn = createColumn("REGION", SQLSimpleTypes.Sql99.varcharType());
+        Column factNAmountColumn = createColumn("AMOUNT", SQLSimpleTypes.Sql99.integerType());
         Table factNTable = createTable(FACT_N,
                 List.of(factNCategoryColumn, factNRegionColumn, factNAmountColumn));
         databaseSchema.getOwnedElement().add(factNTable);
 
-        Column factTCategoryColumn = createColumn("CATEGORY", SqlSimpleTypes.Sql99.varcharType());
-        Column factTRegionColumn = createColumn("REGION", SqlSimpleTypes.Sql99.varcharType());
-        Column factTValueColumn = createColumn("VALUE", SqlSimpleTypes.Sql99.integerType());
-        Column factTCommentColumn = createColumn("COMMENT", SqlSimpleTypes.Sql99.varcharType());
+        Column factTCategoryColumn = createColumn("CATEGORY", SQLSimpleTypes.Sql99.varcharType());
+        Column factTRegionColumn = createColumn("REGION", SQLSimpleTypes.Sql99.varcharType());
+        Column factTValueColumn = createColumn("VALUE", SQLSimpleTypes.Sql99.integerType());
+        Column factTCommentColumn = createColumn("COMMENT", SQLSimpleTypes.Sql99.varcharType());
         Table factTTable = createTable(FACT_T,
                 List.of(factTCategoryColumn, factTRegionColumn, factTValueColumn, factTCommentColumn));
         databaseSchema.getOwnedElement().add(factTTable);
 
-        Column catCategoryColumn = createColumn("CATEGORY", SqlSimpleTypes.Sql99.varcharType());
-        Column catNameColumn = createColumn("NAME", SqlSimpleTypes.Sql99.varcharType());
+        Column catCategoryColumn = createColumn("CATEGORY", SQLSimpleTypes.Sql99.varcharType());
+        Column catNameColumn = createColumn("NAME", SQLSimpleTypes.Sql99.varcharType());
         Table categoryTable = createTable(CATEGORY, List.of(catCategoryColumn, catNameColumn));
         databaseSchema.getOwnedElement().add(categoryTable);
 
-        Column regRegionColumn = createColumn("REGION", SqlSimpleTypes.Sql99.varcharType());
-        Column regNameColumn = createColumn("NAME", SqlSimpleTypes.Sql99.varcharType());
+        Column regRegionColumn = createColumn("REGION", SQLSimpleTypes.Sql99.varcharType());
+        Column regNameColumn = createColumn("NAME", SQLSimpleTypes.Sql99.varcharType());
         Table regionTable = createTable(REGION, List.of(regRegionColumn, regNameColumn));
         databaseSchema.getOwnedElement().add(regionTable);
 
-        Column wbCategoryColumn = createColumn("CATEGORY", SqlSimpleTypes.Sql99.varcharType());
-        Column wbRegionColumn = createColumn("REGION", SqlSimpleTypes.Sql99.varcharType());
-        Column wbValueColumn = createColumn("VALUE", SqlSimpleTypes.Sql99.integerType());
-        Column wbCommentColumn = createColumn("COMMENT", SqlSimpleTypes.Sql99.varcharType());
-        Column wbIdColumn = createColumn("ID", SqlSimpleTypes.Sql99.varcharType());
-        Column wbUserColumn = createColumn("USER", SqlSimpleTypes.Sql99.varcharType());
+        Column wbCategoryColumn = createColumn("CATEGORY", SQLSimpleTypes.Sql99.varcharType());
+        Column wbRegionColumn = createColumn("REGION", SQLSimpleTypes.Sql99.varcharType());
+        Column wbValueColumn = createColumn("VALUE", SQLSimpleTypes.Sql99.integerType());
+        Column wbCommentColumn = createColumn("COMMENT", SQLSimpleTypes.Sql99.varcharType());
+        Column wbIdColumn = createColumn("ID", SQLSimpleTypes.Sql99.varcharType());
+        Column wbUserColumn = createColumn("USER", SQLSimpleTypes.Sql99.varcharType());
         Table writebackPhysicalTable = createTable(FACTWB_T,
                 List.of(wbCategoryColumn, wbRegionColumn, wbValueColumn, wbCommentColumn, wbIdColumn, wbUserColumn));
         databaseSchema.getOwnedElement().add(writebackPhysicalTable);

--- a/instance/emf/tutorial/writeback/withoutdimension/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/withoutdimension/CatalogSupplier.java
+++ b/instance/emf/tutorial/writeback/withoutdimension/src/main/java/org/eclipse/daanse/rolap/mapping/instance/emf/tutorial/writeback/withoutdimension/CatalogSupplier.java
@@ -41,7 +41,7 @@ import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.writeback.WritebackFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @Component(service = { CatalogMappingSupplier.class, TutorialDescriptionSupplier.class })
 @MappingInstance(kind = Kind.TUTORIAL, number = "2.05.04", source = Source.EMF, group = "Writeback") // NOSONAR
 public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescriptionSupplier {
@@ -79,15 +79,15 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column valColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valColumn.setName("VAL");
-        valColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column val1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         val1Column.setName("VAL1");
-        val1Column.setType(SqlSimpleTypes.Sql99.integerType());
+        val1Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column l2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         l2Column.setName("VALUE");
-        l2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        l2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName(FACT);
@@ -96,23 +96,23 @@ public class CatalogSupplier implements CatalogMappingSupplier, TutorialDescript
 
         Column factwbValColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbValColumn.setName("VAL");
-        factwbValColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        factwbValColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column factwbVal1Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbVal1Column.setName("VAL1");
-        factwbVal1Column.setType(SqlSimpleTypes.Sql99.integerType());
+        factwbVal1Column.setType(SQLSimpleTypes.Sql99.integerType());
 
         Column factwbL2Column = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbL2Column.setName("VALUE");
-        factwbL2Column.setType(SqlSimpleTypes.Sql99.varcharType());
+        factwbL2Column.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column factwbIdColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbIdColumn.setName("ID");
-        factwbIdColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        factwbIdColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Column factwbUserColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         factwbUserColumn.setName("USER");
-        factwbUserColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        factwbUserColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         Table factwbTable = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         factwbTable.setName("FACTWB");

--- a/verifyer/basic/src/test/java/org/eclipse/daanse/rolap/mapping/verifyer/basic/description/integration/DescriptionVerifyerTest.java
+++ b/verifyer/basic/src/test/java/org/eclipse/daanse/rolap/mapping/verifyer/basic/description/integration/DescriptionVerifyerTest.java
@@ -87,7 +87,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @ExtendWith(BundleContextExtension.class)
 @ExtendWith(ServiceExtension.class)
 @ExtendWith(ConfigurationExtension.class)
@@ -127,11 +127,11 @@ public class DescriptionVerifyerTest {
 
         keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");

--- a/verifyer/basic/src/test/java/org/eclipse/daanse/rolap/mapping/verifyer/basic/mandantory/MandantoriesVerifyerTest.java
+++ b/verifyer/basic/src/test/java/org/eclipse/daanse/rolap/mapping/verifyer/basic/mandantory/MandantoriesVerifyerTest.java
@@ -154,7 +154,7 @@ import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.Hierarchy
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.format.FormatFactory;
 import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 @ExtendWith(BundleContextExtension.class)
 @ExtendWith(ServiceExtension.class)
 class MandantoriesVerifyerTest {
@@ -176,11 +176,11 @@ class MandantoriesVerifyerTest {
 
         keyColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        keyColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         valueColumn = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createColumn();
         valueColumn.setName("VALUE");
-        valueColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        valueColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
         table.setName("Fact");


### PR DESCRIPTION
An SQLIndex holds SQLIndexColumn, as CWM 6.3.16 has it, and both CatalogSupplier now reach for SQLIndexes.index instead of carrying their own copy of it. SqlSimpleTypes reads SQLSimpleTypes.
